### PR TITLE
Bump version to 0.0.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,11 @@ lock: ## Generate Pipfile.lock and requirements.txt
 .PHONY: package
 package: ## Package for distribution
 	rm -rf dist && \
-	python setup.py bdist_wheel
+	python3 setup.py sdist bdist_wheel
+
+.PHONY: publish
+publish: package ## Publish package to PyPI
+	twine upload dist/*
 
 .PHONY: docs
 docs: ## Generate sphinx HTML documentation

--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,7 @@ name = "pypi"
 
 [packages]
 requests = "*"
-typing = "*"
+typing = {version = "*", markers="python_version < '3.5'"}
 
 [dev-packages]
 black = "*"
@@ -16,7 +16,9 @@ mypy = "*"
 pylint = "*"
 pytest = "*"
 recommonmark = "*"
+setuptools = "*"
 sphinx = "*"
+twine = "*"
 wheel = "*"
 
 [requires]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "0ac8e36b89fcf33debc90c0722c0dc348aa20358b2725a7ca3aa60410e806c59"
+            "sha256": "957eb20276d72ec8e855863394f90e782030c46922415ec521a7d1ccc68e9967"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -35,7 +35,6 @@
                 "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
                 "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
             ],
-            "markers": "python_version >= '2.7' and python_version != '3.0.*' and python_version != '3.1.*' and python_version != '3.2.*' and python_version != '3.3.*'",
             "version": "==2.8"
         },
         "requests": {
@@ -53,6 +52,7 @@
                 "sha256:a4c8473ce11a65999c8f59cb093e70686b6c84c98df58c1dae9b3b196089858a"
             ],
             "index": "pypi",
+            "markers": "python_version < '3.5'",
             "version": "==3.6.6"
         },
         "urllib3": {
@@ -60,7 +60,6 @@
                 "sha256:61bf29cada3fc2fbefad4fdf059ea4bd1b4a86d2b6d15e1c7c0b582b9752fe39",
                 "sha256:de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22"
             ],
-            "markers": "python_version >= '2.7' and python_version != '3.0.*' and python_version < '4' and python_version != '3.1.*' and python_version != '3.2.*' and python_version != '3.3.*'",
             "version": "==1.24.1"
         }
     },
@@ -91,7 +90,6 @@
                 "sha256:0312ad34fcad8fac3704d441f7b317e50af620823353ec657a53e981f92920c0",
                 "sha256:ec9ae8adaae229e4f8446952d204a3e4b5fdd2d099f9be3aaf556120135fb3ee"
             ],
-            "markers": "python_version >= '2.7' and python_version != '3.0.*' and python_version != '3.1.*' and python_version != '3.2.*' and python_version != '3.3.*'",
             "version": "==1.2.1"
         },
         "attrs": {
@@ -116,6 +114,13 @@
             "index": "pypi",
             "version": "==18.9b0"
         },
+        "bleach": {
+            "hashes": [
+                "sha256:48d39675b80a75f6d1c3bdbffec791cf0bbbab665cf01e20da701c77de278718",
+                "sha256:73d26f018af5d5adcdabf5c1c974add4361a9c76af215fe32fdec8a6fc5fb9b9"
+            ],
+            "version": "==3.0.2"
+        },
         "certifi": {
             "hashes": [
                 "sha256:47f9c83ef4c0c621eaef743f133f09fa8a74a9b75f037e8624f83bd1b6626cb7",
@@ -135,7 +140,6 @@
                 "sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13",
                 "sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"
             ],
-            "markers": "python_version >= '2.7' and python_version != '3.0.*' and python_version != '3.1.*' and python_version != '3.2.*' and python_version != '3.3.*'",
             "version": "==7.0"
         },
         "colorlog": {
@@ -180,7 +184,6 @@
                 "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
                 "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
             ],
-            "markers": "python_version >= '2.7' and python_version != '3.0.*' and python_version != '3.1.*' and python_version != '3.2.*' and python_version != '3.3.*'",
             "version": "==2.8"
         },
         "imagesize": {
@@ -188,7 +191,6 @@
                 "sha256:3f349de3eb99145973fefb7dbe38554414e5c30abd0c8e4b970a7c9d09f3a1d8",
                 "sha256:f3832918bc3c66617f92e35f5d70729187676313caa60c187eb0f28b8fe5e3b5"
             ],
-            "markers": "python_version >= '2.7' and python_version != '3.0.*' and python_version != '3.1.*' and python_version != '3.2.*' and python_version != '3.3.*'",
             "version": "==1.1.0"
         },
         "isort": {
@@ -197,7 +199,6 @@
                 "sha256:b9c40e9750f3d77e6e4d441d8b0266cf555e7cdabdcff33c4fd06366ca761ef8",
                 "sha256:ec9ef8f4a9bc6f71eec99e1806bfa2de401650d996c59330782b89a5555c1497"
             ],
-            "markers": "python_version >= '2.7' and python_version != '3.0.*' and python_version != '3.1.*' and python_version != '3.2.*' and python_version != '3.3.*'",
             "version": "==4.3.4"
         },
         "jinja2": {
@@ -205,7 +206,6 @@
                 "sha256:74c935a1b8bb9a3947c50a54766a969d4846290e1e788ea44c1392163723c3bd",
                 "sha256:f84be1bb0040caca4cea721fcbbbbd61f9be9464ca236387158b0feea01914a4"
             ],
-            "markers": "python_version >= '2.7' and python_version != '3.0.*' and python_version != '3.1.*' and python_version != '3.2.*' and python_version != '3.3.*'",
             "version": "==2.10"
         },
         "lazy-object-proxy": {
@@ -273,7 +273,6 @@
                 "sha256:f82e347a72f955b7017a39708a3667f106e6ad4d10b25f237396a7115d8ed5fd",
                 "sha256:fb7c206e01ad85ce57feeaaa0bf784b97fa3cad0d4a5737bc5295785f5c613a1"
             ],
-            "markers": "python_version >= '2.7' and python_version != '3.0.*' and python_version != '3.1.*' and python_version != '3.2.*' and python_version != '3.3.*'",
             "version": "==1.1.0"
         },
         "mccabe": {
@@ -285,12 +284,11 @@
         },
         "more-itertools": {
             "hashes": [
-                "sha256:c187a73da93e7a8acc0001572aebc7e3c69daf7bf6881a2cea10650bd4420092",
-                "sha256:c476b5d3a34e12d40130bc2f935028b5f636df8f372dc2c1c01dc19681b2039e",
-                "sha256:fcbfeaea0be121980e15bc97b3817b5202ca73d0eae185b4550cbfce2a3ebb3d"
+                "sha256:38a936c0a6d98a38bcc2d03fdaaedaba9f412879461dd2ceff8d37564d6522e4",
+                "sha256:c0a5785b1109a6bd7fac76d6837fd1feca158e54e521ccd2ae8bfe393cc9d4fc",
+                "sha256:fe7a7cae1ccb57d33952113ff4fa1bc5f879963600ed74918f1236e212ee50b9"
             ],
-            "markers": "python_version != '3.0.*' and python_version != '3.1.*' and python_version >= '2.6'",
-            "version": "==4.3.0"
+            "version": "==5.0.0"
         },
         "mypy": {
             "hashes": [
@@ -320,15 +318,20 @@
                 "sha256:0886227f54515e592aaa2e5a553332c73962917f2831f1b0f9b9f4380a4b9807",
                 "sha256:f95a1e147590f204328170981833854229bb2912ac3d5f89e2a8ccd2834800c9"
             ],
-            "markers": "python_version != '3.0.*' and python_version != '3.1.*' and python_version >= '2.6'",
             "version": "==18.0"
+        },
+        "pkginfo": {
+            "hashes": [
+                "sha256:5878d542a4b3f237e359926384f1dde4e099c9f5525d236b1840cf704fa8d474",
+                "sha256:a39076cb3eb34c333a0dd390b568e9e1e881c7bf2cc0aee12120636816f55aee"
+            ],
+            "version": "==1.4.2"
         },
         "pluggy": {
             "hashes": [
                 "sha256:447ba94990e8014ee25ec853339faf7b0fc8050cdc3289d4d71f7f410fb90095",
                 "sha256:bde19360a8ec4dfd8a20dcb811780a30998101f078fc7ded6162f0076f50508f"
             ],
-            "markers": "python_version >= '2.7' and python_version != '3.0.*' and python_version != '3.1.*' and python_version != '3.2.*' and python_version != '3.3.*'",
             "version": "==0.8.0"
         },
         "py": {
@@ -336,7 +339,6 @@
                 "sha256:bf92637198836372b520efcba9e020c330123be8ce527e535d185ed4b6f45694",
                 "sha256:e76826342cefe3c3d5f7e8ee4316b80d1dd8a300781612ddbc765c17ba25a6c6"
             ],
-            "markers": "python_version >= '2.7' and python_version != '3.0.*' and python_version != '3.1.*' and python_version != '3.2.*' and python_version != '3.3.*'",
             "version": "==1.7.0"
         },
         "pycodestyle": {
@@ -351,7 +353,6 @@
                 "sha256:9a7662ec724d0120012f6e29d6248ae3727d821bba522a0e6b356eff19126a49",
                 "sha256:f661252913bc1dbe7fcfcbf0af0db3f42ab65aabd1a6ca68fe5d466bace94dae"
             ],
-            "markers": "python_version >= '2.7' and python_version != '3.0.*' and python_version != '3.1.*' and python_version != '3.2.*' and python_version != '3.3.*'",
             "version": "==2.0.0"
         },
         "pygments": {
@@ -374,7 +375,6 @@
                 "sha256:40856e74d4987de5d01761a22d1621ae1c7f8774585acae358aa5c5936c6c90b",
                 "sha256:f353aab21fd474459d97b709e527b5571314ee5f067441dc9f88e33eecd96592"
             ],
-            "markers": "python_version != '3.0.*' and python_version != '3.1.*' and python_version != '3.2.*' and python_version >= '2.6'",
             "version": "==2.3.0"
         },
         "pytest": {
@@ -392,6 +392,13 @@
             ],
             "version": "==2018.7"
         },
+        "readme-renderer": {
+            "hashes": [
+                "sha256:bb16f55b259f27f75f640acf5e00cf897845a8b3e4731b5c1a436e4b8529202f",
+                "sha256:c8532b79afc0375a85f10433eca157d6b50f7d6990f337fa498c96cd4bfc203d"
+            ],
+            "version": "==24.0"
+        },
         "recommonmark": {
             "hashes": [
                 "sha256:6e29c723abcf5533842376d87c4589e62923ecb6002a8e059eb608345ddaff9d",
@@ -408,12 +415,18 @@
             "index": "pypi",
             "version": "==2.21.0"
         },
+        "requests-toolbelt": {
+            "hashes": [
+                "sha256:42c9c170abc2cacb78b8ab23ac957945c7716249206f90874651971a4acff237",
+                "sha256:f6a531936c6fa4c6cfce1b9c10d5c4f498d16528d2a54a22ca00011205a187b5"
+            ],
+            "version": "==0.8.0"
+        },
         "six": {
             "hashes": [
                 "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
                 "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
             ],
-            "markers": "python_version != '3.0.*' and python_version != '3.1.*' and python_version >= '2.6'",
             "version": "==1.12.0"
         },
         "snowballstemmer": {
@@ -425,18 +438,17 @@
         },
         "sphinx": {
             "hashes": [
-                "sha256:120732cbddb1b2364471c3d9f8bfd4b0c5b550862f99a65736c77f970b142aea",
-                "sha256:b348790776490894e0424101af9c8413f2a86831524bd55c5f379d3e3e12ca64"
+                "sha256:429e3172466df289f0f742471d7e30ba3ee11f3b5aecd9a840480d03f14bcfe5",
+                "sha256:c4cb17ba44acffae3d3209646b6baec1e215cad3065e852c68cc569d4df1b9f8"
             ],
             "index": "pypi",
-            "version": "==1.8.2"
+            "version": "==1.8.3"
         },
         "sphinxcontrib-websupport": {
             "hashes": [
                 "sha256:68ca7ff70785cbe1e7bccc71a48b5b6d965d79ca50629606c7861a21b206d9dd",
                 "sha256:9de47f375baf1ea07cdb3436ff39d7a9c76042c10a769c52353ec46e4e8fc3b9"
             ],
-            "markers": "python_version >= '2.7' and python_version != '3.0.*' and python_version != '3.1.*' and python_version != '3.2.*' and python_version != '3.3.*'",
             "version": "==1.1.0"
         },
         "toml": {
@@ -445,6 +457,21 @@
                 "sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e"
             ],
             "version": "==0.10.0"
+        },
+        "tqdm": {
+            "hashes": [
+                "sha256:3c4d4a5a41ef162dd61f1edb86b0e1c7859054ab656b2e7c7b77e7fbf6d9f392",
+                "sha256:5b4d5549984503050883bc126280b386f5f4ca87e6c023c5d015655ad75bdebb"
+            ],
+            "version": "==4.28.1"
+        },
+        "twine": {
+            "hashes": [
+                "sha256:7d89bc6acafb31d124e6e5b295ef26ac77030bf098960c2a4c4e058335827c5c",
+                "sha256:fad6f1251195f7ddd1460cb76d6ea106c93adb4e56c41e0da79658e56e547d2c"
+            ],
+            "index": "pypi",
+            "version": "==1.12.1"
         },
         "typed-ast": {
             "hashes": [
@@ -477,16 +504,20 @@
                 "sha256:61bf29cada3fc2fbefad4fdf059ea4bd1b4a86d2b6d15e1c7c0b582b9752fe39",
                 "sha256:de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22"
             ],
-            "markers": "python_version >= '2.7' and python_version != '3.0.*' and python_version < '4' and python_version != '3.1.*' and python_version != '3.2.*' and python_version != '3.3.*'",
             "version": "==1.24.1"
         },
         "virtualenv": {
             "hashes": [
-                "sha256:686176c23a538ecc56d27ed9d5217abd34644823d6391cbeb232f42bf722baad",
-                "sha256:f899fafcd92e1150f40c8215328be38ff24b519cd95357fa6e78e006c7638208"
+                "sha256:34b9ae3742abed2f95d3970acf4d80533261d6061b51160b197f84e5b4c98b4c"
             ],
-            "markers": "python_version >= '2.7' and python_version != '3.0.*' and python_version != '3.1.*' and python_version != '3.2.*' and python_version != '3.3.*'",
-            "version": "==16.1.0"
+            "version": "==16.2.0"
+        },
+        "webencodings": {
+            "hashes": [
+                "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78",
+                "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"
+            ],
+            "version": "==0.5.1"
         },
         "wheel": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Python 2.7 and 3.5+ are supported, Python 3.6+ is recommended.
 Install with [pipenv](https://pipenv.readthedocs.io/en/latest/), pip, or another package manager.
 
 ```bash
-pipenv install -e git+ssh://git@github.com/cruxinformatics/crux-python.git@master#egg=crux
+pipenv install "crux==0.0.2"
 ```
 
 Use the `crux` module.
@@ -38,7 +38,7 @@ Python 3.7 is required for development, which can be installed with `brew instal
 [Pipenv](https://pipenv.readthedocs.io/en/latest/) should be used to manage dependancies during development.
 
 1. [Install Pipenv](https://pipenv.readthedocs.io/en/latest/install/#installing-pipenv), on macOS run `brew install pipenv`
-2. `git clone git@github.com:cruxinformatics/crux-python.git`
+2. `git clone https://github.com/cruxinformatics/crux-python.git`
 3. `cd crux-python`
 4. `pipenv install --dev` to install the dependancies
 5. `pipenv shell` to get a shell in the virtual environment

--- a/crux/__version__.py
+++ b/crux/__version__.py
@@ -1,3 +1,3 @@
 """Module contains version and other package information."""
 
-__version__ = "0.0.1"
+__version__ = "0.0.2"

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ brew install pipenv
 Install `crux` in a virtual environment, and get a shell in that environment:
 
 ```bash
-pipenv install -e git+ssh://git@github.com/cruxinformatics/crux-python.git@master#egg=crux
+pipenv install "crux==0.0.2"
 pipenv shell
 ```
 ## Getting Started

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -17,13 +17,13 @@ See the [Pipenv installation instructions](https://pipenv.readthedocs.io/en/late
 Once Pipenv is installed, change into the root of your application directory and run:
 
 ```bash
-pipenv install -e git+ssh://git@github.com/cruxinformatics/crux-python.git@master#egg=crux
+pipenv install "crux==0.0.2"
 ```
 
 This will add a line to the `[packages]` section of your Pipfile, or create a new Pipfile if one doesn't exist.
 
 ```ini
-crux = {editable = true, ref = "master", git = "ssh://git@github.com/cruxinformatics/crux-python.git"}
+crux = "==0.0.2"
 ```
 
 ## With venv and pip
@@ -33,6 +33,6 @@ Alternatively you can create a virtual environment with Python 3's [venv module]
 ```bash
 python3 -m venv .venv
 source .venv/bin/activate
-python3 -m pip install -e git+ssh://git@github.com/cruxinformatics/crux-python.git@master#egg=crux
+python3 -m pip install "crux==0.0.2"
 python3 -m pip freeze > requirements.txt
 ```

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,48 +2,55 @@
 alabaster==0.7.12
 appdirs==1.4.3
 astroid==2.1.0
-atomicwrites==1.2.1; python_version != '3.3.*'
+atomicwrites==1.2.1
 attrs==18.2.0
 babel==2.6.0
 black==18.9b0
+bleach==3.0.2
 certifi==2018.11.29
 chardet==3.0.4
-click==7.0; python_version != '3.3.*'
+click==7.0
 colorlog==3.2.0
 commonmark==0.5.4
 docutils==0.14
 flake8-import-order==0.18
 flake8==3.6.0
-idna==2.8; python_version != '3.3.*'
-imagesize==1.1.0; python_version != '3.3.*'
-isort==4.3.4; python_version != '3.3.*'
-jinja2==2.10; python_version != '3.3.*'
+idna==2.8
+imagesize==1.1.0
+isort==4.3.4
+jinja2==2.10
 lazy-object-proxy==1.3.1
-markupsafe==1.1.0; python_version != '3.3.*'
+markupsafe==1.1.0
 mccabe==0.6.1
-more-itertools==4.3.0; python_version >= '2.6'
+more-itertools==5.0.0
 mypy-extensions==0.4.1
 mypy==0.650
 nox==2018.10.17
-packaging==18.0; python_version >= '2.6'
-pluggy==0.8.0; python_version != '3.3.*'
-py==1.7.0; python_version != '3.3.*'
+packaging==18.0
+pkginfo==1.4.2
+pluggy==0.8.0
+py==1.7.0
 pycodestyle==2.4.0
-pyflakes==2.0.0; python_version != '3.3.*'
+pyflakes==2.0.0
 pygments==2.3.1
 pylint==2.2.2
-pyparsing==2.3.0; python_version >= '2.6'
+pyparsing==2.3.0
 pytest==4.0.2
 pytz==2018.7
+readme-renderer==24.0
 recommonmark==0.4.0
+requests-toolbelt==0.8.0
 requests==2.21.0
-six==1.12.0; python_version >= '2.6'
+six==1.12.0
 snowballstemmer==1.2.1
-sphinx==1.8.2
-sphinxcontrib-websupport==1.1.0; python_version != '3.3.*'
+sphinx==1.8.3
+sphinxcontrib-websupport==1.1.0
 toml==0.10.0
+tqdm==4.28.1
+twine==1.12.1
 typed-ast==1.1.1
-urllib3==1.24.1; python_version != '3.3.*'
-virtualenv==16.1.0; python_version != '3.3.*'
+urllib3==1.24.1
+virtualenv==16.2.0
+webencodings==0.5.1
 wheel==0.32.3
 wrapt==1.10.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 -i https://pypi.org/simple
 certifi==2018.11.29
 chardet==3.0.4
-idna==2.8; python_version != '3.3.*'
+idna==2.8
 requests==2.21.0
-typing==3.6.6
-urllib3==1.24.1; python_version != '3.3.*'
+typing==3.6.6 ; python_version < '3.5'
+urllib3==1.24.1

--- a/setup.py
+++ b/setup.py
@@ -4,21 +4,22 @@ Setup file for Python packaging.
 
 import os
 
-from setuptools import setup
+from setuptools import find_packages, setup
 
 here = os.path.abspath(os.path.dirname(__file__))
-requirements = ["requests", "typing;python_version=='2.7'"]
+requirements = ["requests", "typing;python_version<'3.5'"]
+packages = [pkg for pkg in find_packages() if pkg.startswith("crux")]
 
 version = {}
-with open(os.path.join(here, "crux", "__version__.py"), "r", "utf-8") as fh:
-    exec(fh.read(), globals=version)  # pylint: disable=exec-used
+with open(os.path.join(here, "crux", "__version__.py"), "r", encoding="utf-8") as fh:
+    exec(fh.read(), version)
 
-with open("README.md", "r", "utf-8") as fh:
+with open("README.md", "r", encoding="utf-8") as fh:
     readme = fh.read()
 
 setup(
     name="crux",
-    packages=["crux", "crux.models"],
+    packages=packages,
     version=version["__version__"],
     description="Crux Informatics API client library",
     long_description=readme,


### PR DESCRIPTION
- Bump version to 0.0.2, it is now uploaded to PyPI
- Build sdist in addition to bdist_wheel, for Python 2.7 support
- Make the `typing` python_version < 3.5 because that is more
  accurate than restricting to 2.7
- Add dev dependancies for packaging and publishing
- Change install instructions to install from PyPI

**Test Plan:**

I was able to publish to PyPI and install from PyPI.

`make unit` and `make lint` pass.