### PR TITLE
Refactor conf.py to publish module documentation.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,5 +1,3 @@
-# .readthedocs.yml
-
 build:
   image: latest
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,14 @@
+# .readthedocs.yml
+
+build:
+  image: latest
+
+python:
+  version: 3.6
+  setup_py_install: true
+
+formats:
+  - epub
+  - pdf
+
+requirements_file: requirements-dev.txt

--- a/Makefile
+++ b/Makefile
@@ -55,5 +55,4 @@ publish: package ## Publish package to PyPI
 .PHONY: docs
 docs: ## Generate sphinx HTML documentation
 	cd docs && \
-	sphinx-apidoc -o ./ ../crux && \
 	make html

--- a/Pipfile
+++ b/Pipfile
@@ -18,6 +18,7 @@ pytest = "*"
 recommonmark = "*"
 setuptools = "*"
 sphinx = "*"
+sphinxcontrib-apidoc = "*"
 twine = "*"
 wheel = "*"
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "957eb20276d72ec8e855863394f90e782030c46922415ec521a7d1ccc68e9967"
+            "sha256": "2543a1a4a5f4d6795a965991afb3dfa89b075f4a58a0e052328a710b4c895e38"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -35,6 +35,7 @@
                 "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
                 "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
             ],
+            "markers": "python_version >= '2.7' and python_version != '3.0.*' and python_version != '3.1.*' and python_version != '3.2.*' and python_version != '3.3.*'",
             "version": "==2.8"
         },
         "requests": {
@@ -60,6 +61,7 @@
                 "sha256:61bf29cada3fc2fbefad4fdf059ea4bd1b4a86d2b6d15e1c7c0b582b9752fe39",
                 "sha256:de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22"
             ],
+            "markers": "python_version >= '2.7' and python_version != '3.0.*' and python_version < '4' and python_version != '3.1.*' and python_version != '3.2.*' and python_version != '3.3.*'",
             "version": "==1.24.1"
         }
     },
@@ -90,6 +92,7 @@
                 "sha256:0312ad34fcad8fac3704d441f7b317e50af620823353ec657a53e981f92920c0",
                 "sha256:ec9ae8adaae229e4f8446952d204a3e4b5fdd2d099f9be3aaf556120135fb3ee"
             ],
+            "markers": "python_version >= '2.7' and python_version != '3.0.*' and python_version != '3.1.*' and python_version != '3.2.*' and python_version != '3.3.*'",
             "version": "==1.2.1"
         },
         "attrs": {
@@ -119,6 +122,7 @@
                 "sha256:48d39675b80a75f6d1c3bdbffec791cf0bbbab665cf01e20da701c77de278718",
                 "sha256:73d26f018af5d5adcdabf5c1c974add4361a9c76af215fe32fdec8a6fc5fb9b9"
             ],
+            "markers": "python_version >= '2.6' and python_version != '3.0.*' and python_version != '3.1.*'",
             "version": "==3.0.2"
         },
         "certifi": {
@@ -140,6 +144,7 @@
                 "sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13",
                 "sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"
             ],
+            "markers": "python_version >= '2.7' and python_version != '3.0.*' and python_version != '3.1.*' and python_version != '3.2.*' and python_version != '3.3.*'",
             "version": "==7.0"
         },
         "colorlog": {
@@ -184,6 +189,7 @@
                 "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
                 "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
             ],
+            "markers": "python_version >= '2.7' and python_version != '3.0.*' and python_version != '3.1.*' and python_version != '3.2.*' and python_version != '3.3.*'",
             "version": "==2.8"
         },
         "imagesize": {
@@ -191,6 +197,7 @@
                 "sha256:3f349de3eb99145973fefb7dbe38554414e5c30abd0c8e4b970a7c9d09f3a1d8",
                 "sha256:f3832918bc3c66617f92e35f5d70729187676313caa60c187eb0f28b8fe5e3b5"
             ],
+            "markers": "python_version >= '2.7' and python_version != '3.0.*' and python_version != '3.1.*' and python_version != '3.2.*' and python_version != '3.3.*'",
             "version": "==1.1.0"
         },
         "isort": {
@@ -199,6 +206,7 @@
                 "sha256:b9c40e9750f3d77e6e4d441d8b0266cf555e7cdabdcff33c4fd06366ca761ef8",
                 "sha256:ec9ef8f4a9bc6f71eec99e1806bfa2de401650d996c59330782b89a5555c1497"
             ],
+            "markers": "python_version >= '2.7' and python_version != '3.0.*' and python_version != '3.1.*' and python_version != '3.2.*' and python_version != '3.3.*'",
             "version": "==4.3.4"
         },
         "jinja2": {
@@ -206,6 +214,7 @@
                 "sha256:74c935a1b8bb9a3947c50a54766a969d4846290e1e788ea44c1392163723c3bd",
                 "sha256:f84be1bb0040caca4cea721fcbbbbd61f9be9464ca236387158b0feea01914a4"
             ],
+            "markers": "python_version >= '2.7' and python_version != '3.0.*' and python_version != '3.1.*' and python_version != '3.2.*' and python_version != '3.3.*'",
             "version": "==2.10"
         },
         "lazy-object-proxy": {
@@ -273,6 +282,7 @@
                 "sha256:f82e347a72f955b7017a39708a3667f106e6ad4d10b25f237396a7115d8ed5fd",
                 "sha256:fb7c206e01ad85ce57feeaaa0bf784b97fa3cad0d4a5737bc5295785f5c613a1"
             ],
+            "markers": "python_version >= '2.7' and python_version != '3.0.*' and python_version != '3.1.*' and python_version != '3.2.*' and python_version != '3.3.*'",
             "version": "==1.1.0"
         },
         "mccabe": {
@@ -288,6 +298,7 @@
                 "sha256:c0a5785b1109a6bd7fac76d6837fd1feca158e54e521ccd2ae8bfe393cc9d4fc",
                 "sha256:fe7a7cae1ccb57d33952113ff4fa1bc5f879963600ed74918f1236e212ee50b9"
             ],
+            "markers": "python_version >= '2.6' and python_version != '3.0.*' and python_version != '3.1.*'",
             "version": "==5.0.0"
         },
         "mypy": {
@@ -318,7 +329,15 @@
                 "sha256:0886227f54515e592aaa2e5a553332c73962917f2831f1b0f9b9f4380a4b9807",
                 "sha256:f95a1e147590f204328170981833854229bb2912ac3d5f89e2a8ccd2834800c9"
             ],
+            "markers": "python_version != '3.0.*' and python_version != '3.1.*' and python_version >= '2.6'",
             "version": "==18.0"
+        },
+        "pbr": {
+            "hashes": [
+                "sha256:f59d71442f9ece3dffc17bc36575768e1ee9967756e6b6535f0ee1f0054c3d68",
+                "sha256:f6d5b23f226a2ba58e14e49aa3b1bfaf814d0199144b95d78458212444de1387"
+            ],
+            "version": "==5.1.1"
         },
         "pkginfo": {
             "hashes": [
@@ -332,6 +351,7 @@
                 "sha256:447ba94990e8014ee25ec853339faf7b0fc8050cdc3289d4d71f7f410fb90095",
                 "sha256:bde19360a8ec4dfd8a20dcb811780a30998101f078fc7ded6162f0076f50508f"
             ],
+            "markers": "python_version >= '2.7' and python_version != '3.0.*' and python_version != '3.1.*' and python_version != '3.2.*' and python_version != '3.3.*'",
             "version": "==0.8.0"
         },
         "py": {
@@ -339,6 +359,7 @@
                 "sha256:bf92637198836372b520efcba9e020c330123be8ce527e535d185ed4b6f45694",
                 "sha256:e76826342cefe3c3d5f7e8ee4316b80d1dd8a300781612ddbc765c17ba25a6c6"
             ],
+            "markers": "python_version >= '2.7' and python_version != '3.0.*' and python_version != '3.1.*' and python_version != '3.2.*' and python_version != '3.3.*'",
             "version": "==1.7.0"
         },
         "pycodestyle": {
@@ -353,6 +374,7 @@
                 "sha256:9a7662ec724d0120012f6e29d6248ae3727d821bba522a0e6b356eff19126a49",
                 "sha256:f661252913bc1dbe7fcfcbf0af0db3f42ab65aabd1a6ca68fe5d466bace94dae"
             ],
+            "markers": "python_version >= '2.7' and python_version != '3.0.*' and python_version != '3.1.*' and python_version != '3.2.*' and python_version != '3.3.*'",
             "version": "==2.0.0"
         },
         "pygments": {
@@ -375,6 +397,7 @@
                 "sha256:40856e74d4987de5d01761a22d1621ae1c7f8774585acae358aa5c5936c6c90b",
                 "sha256:f353aab21fd474459d97b709e527b5571314ee5f067441dc9f88e33eecd96592"
             ],
+            "markers": "python_version != '3.0.*' and python_version != '3.1.*' and python_version != '3.2.*' and python_version >= '2.6'",
             "version": "==2.3.0"
         },
         "pytest": {
@@ -427,6 +450,7 @@
                 "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
                 "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
             ],
+            "markers": "python_version != '3.0.*' and python_version != '3.1.*' and python_version >= '2.6'",
             "version": "==1.12.0"
         },
         "snowballstemmer": {
@@ -444,11 +468,20 @@
             "index": "pypi",
             "version": "==1.8.3"
         },
+        "sphinxcontrib-apidoc": {
+            "hashes": [
+                "sha256:6671a46b2c6c5b0dca3d8a147849d159065e50443df79614f921b42fbd15cb09",
+                "sha256:729bf592cf7b7dd57c4c05794f732dc026127275d785c2a5494521fdde773fb9"
+            ],
+            "index": "pypi",
+            "version": "==0.3.0"
+        },
         "sphinxcontrib-websupport": {
             "hashes": [
                 "sha256:68ca7ff70785cbe1e7bccc71a48b5b6d965d79ca50629606c7861a21b206d9dd",
                 "sha256:9de47f375baf1ea07cdb3436ff39d7a9c76042c10a769c52353ec46e4e8fc3b9"
             ],
+            "markers": "python_version >= '2.7' and python_version != '3.0.*' and python_version != '3.1.*' and python_version != '3.2.*' and python_version != '3.3.*'",
             "version": "==1.1.0"
         },
         "toml": {
@@ -463,6 +496,7 @@
                 "sha256:3c4d4a5a41ef162dd61f1edb86b0e1c7859054ab656b2e7c7b77e7fbf6d9f392",
                 "sha256:5b4d5549984503050883bc126280b386f5f4ca87e6c023c5d015655ad75bdebb"
             ],
+            "markers": "python_version >= '2.6' and python_version != '3.0.*' and python_version != '3.1.*'",
             "version": "==4.28.1"
         },
         "twine": {
@@ -504,12 +538,14 @@
                 "sha256:61bf29cada3fc2fbefad4fdf059ea4bd1b4a86d2b6d15e1c7c0b582b9752fe39",
                 "sha256:de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22"
             ],
+            "markers": "python_version >= '2.7' and python_version != '3.0.*' and python_version < '4' and python_version != '3.1.*' and python_version != '3.2.*' and python_version != '3.3.*'",
             "version": "==1.24.1"
         },
         "virtualenv": {
             "hashes": [
                 "sha256:34b9ae3742abed2f95d3970acf4d80533261d6061b51160b197f84e5b4c98b4c"
             ],
+            "markers": "python_version >= '2.7' and python_version != '3.0.*' and python_version != '3.1.*' and python_version != '3.3.*' and python_version != '3.2.*'",
             "version": "==16.2.0"
         },
         "webencodings": {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -184,8 +184,8 @@ texinfo_documents = [
         u"crux-python Documentation",
         author,
         "crux-python",
-        "One line description of project.",
-        "Miscellaneous",
+        "A Python library for interacting with the Crux platform.",
+        "crux-python",
     )
 ]
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,18 +34,10 @@ release = u"{version}".format(version=crux.__version__)
 
 # Use recommonmark.transform.AutoStructify to generate index.html w/toctree
 # from markdown
-github_doc_root = "https://github.com/cruxinformatics/crux-python/tree/master/doc/"
 
 
 def setup(app):
-    app.add_config_value(
-        "recommonmark_config",
-        {
-            "url_resolver": lambda url: github_doc_root + url,
-            "enable_auto_doc_ref": False,
-        },
-        True,
-    )
+    app.add_config_value("recommonmark_config", {"enable_eval_rst": True}, True)
     app.add_transform(AutoStructify)
 
 
@@ -66,7 +58,14 @@ extensions = [
     "sphinx.ext.mathjax",
     "sphinx.ext.githubpages",
     "sphinx.ext.napoleon",
+    "sphinxcontrib.apidoc",
 ]
+
+# Add module path that contains api docstrings.
+apidoc_module_dir = "../crux"
+
+# Add the path which will store the generated api documentation.
+apidoc_output_dir = "./"
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,55 +2,57 @@
 alabaster==0.7.12
 appdirs==1.4.3
 astroid==2.1.0
-atomicwrites==1.2.1
+atomicwrites==1.2.1; python_version != '3.3.*'
 attrs==18.2.0
 babel==2.6.0
 black==18.9b0
-bleach==3.0.2
+bleach==3.0.2; python_version != '3.1.*'
 certifi==2018.11.29
 chardet==3.0.4
-click==7.0
+click==7.0; python_version != '3.3.*'
 colorlog==3.2.0
 commonmark==0.5.4
 docutils==0.14
 flake8-import-order==0.18
 flake8==3.6.0
-idna==2.8
-imagesize==1.1.0
-isort==4.3.4
-jinja2==2.10
+idna==2.8; python_version != '3.3.*'
+imagesize==1.1.0; python_version != '3.3.*'
+isort==4.3.4; python_version != '3.3.*'
+jinja2==2.10; python_version != '3.3.*'
 lazy-object-proxy==1.3.1
-markupsafe==1.1.0
+markupsafe==1.1.0; python_version != '3.3.*'
 mccabe==0.6.1
-more-itertools==5.0.0
+more-itertools==5.0.0; python_version != '3.1.*'
 mypy-extensions==0.4.1
 mypy==0.650
 nox==2018.10.17
-packaging==18.0
+packaging==18.0; python_version >= '2.6'
+pbr==5.1.1
 pkginfo==1.4.2
-pluggy==0.8.0
-py==1.7.0
+pluggy==0.8.0; python_version != '3.3.*'
+py==1.7.0; python_version != '3.3.*'
 pycodestyle==2.4.0
-pyflakes==2.0.0
+pyflakes==2.0.0; python_version != '3.3.*'
 pygments==2.3.1
 pylint==2.2.2
-pyparsing==2.3.0
+pyparsing==2.3.0; python_version >= '2.6'
 pytest==4.0.2
 pytz==2018.7
 readme-renderer==24.0
 recommonmark==0.4.0
 requests-toolbelt==0.8.0
 requests==2.21.0
-six==1.12.0
+six==1.12.0; python_version >= '2.6'
 snowballstemmer==1.2.1
 sphinx==1.8.3
-sphinxcontrib-websupport==1.1.0
+sphinxcontrib-apidoc==0.3.0
+sphinxcontrib-websupport==1.1.0; python_version != '3.3.*'
 toml==0.10.0
-tqdm==4.28.1
+tqdm==4.28.1; python_version != '3.1.*'
 twine==1.12.1
 typed-ast==1.1.1
-urllib3==1.24.1
-virtualenv==16.2.0
+urllib3==1.24.1; python_version != '3.3.*'
+virtualenv==16.2.0; python_version != '3.2.*'
 webencodings==0.5.1
 wheel==0.32.3
 wrapt==1.10.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 -i https://pypi.org/simple
 certifi==2018.11.29
 chardet==3.0.4
-idna==2.8
+idna==2.8; python_version != '3.3.*'
 requests==2.21.0
-typing==3.6.6 ; python_version < '3.5'
-urllib3==1.24.1
+typing==3.6.6; python_version < '3.5'
+urllib3==1.24.1; python_version != '3.3.*'


### PR DESCRIPTION
- Added `enable_eval_rst`.
- Removed `enable_auto_doc_ref` as it is superseded by default linking behaviour.
- Removed `url_resolver` as all of the documentation is self-contained and doesn't reference to external HTTP.
- Added `sphinxcontrib.apidoc` to autogenrate api documentation.
- Removed `sphinx-apidoc` task from `Makefile`.
- Python version is set 3.6 as latest image doesn't contain 3.7.

## Tests

* `make unit` and `make lint` were successful.

```bash
nox > Session lint-3.7 was successful.
nox > Session type_check-3.7 was successful.
nox > Session unit-3.7 was successful.
nox > Ran multiple sessions:
nox > * unit-2.7: success
nox > * unit-3.5: success
nox > * unit-3.6: success
nox > * unit-3.7: success
```
