### PR TITLE
Update documentation links

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 Crux Informatics, Inc.
+Copyright (c) 2019 Crux Informatics, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -4,32 +4,50 @@ A Python library for interacting with the Crux platform.
 
 The aim of this client is to be a Pythonic way to use the Crux API reliably. It covers core functionality, such as uploading and downloading files, but does not cover all API functionality. It isn't an SDK.
 
-Python 2.7 and 3.5+ are supported, Python 3.6+ is recommended.
+Python 3.6+ is recommended. Python 2.7 and 3.5 are supported but deprecated, with support planned for removal in early-2020 and mid-2020 respectively.
 
 **This library is ALPHA.** Breaking changes are expected. Pin to a specific version when using this library, and test upgrades thoroughly.
 
-## Usage
+**See [crux-python.cruxinformatics.com](https://crux-python.cruxinformatics.com/) for detailed documentation.**
 
-Install with [pipenv](https://pipenv.readthedocs.io/en/latest/), pip, or another package manager.
+## Installation
+
+Install a recent version of Python, and a Python dependency and virtual environment manager like [pipenv](https://pipenv.readthedocs.io/en/latest/). On macOS run:
 
 ```bash
-pipenv install "crux==0.0.2"
+brew install python
+brew install pipenv
 ```
 
-Use the `crux` module.
+Install `crux` [from PyPI](https://pypi.org/project/crux/) in a virtual environment, and get a shell in that environment:
+
+```bash
+mkdir -p crux_example
+cd crux_example
+pipenv install "crux==0.0.2"
+pipenv shell
+```
+## Getting Started
+
+Create a file, like example.py, and use the `crux` module:
 
 ```python
 from crux import Crux
 
-# The environment variable CRUX_API_KEY can be set instead of passing api_key to Crux().
-conn = Crux(api_key="YOUR_API_KEY")
-
-dataset = conn.get_dataset("A_DATASET_ID")
-file = dataset.get_file(path="/path/to/file.csv")
-file.download(local_path="/tmp/test.csv")
+conn = Crux()
+identity = conn.whoami()
+print("I am", identity.email)
 ```
 
-**See [docs/](docs/index.md) for detailed documentation.**
+Run the script:
+
+```bash
+HISTCONTROL=ignoreboth
+ export CRUX_API_KEY='YOUR_API_KEY'
+python3 example.py
+```
+
+See the [installation](https://crux-python.cruxinformatics.com/en/latest/installation.html) and [authentication](https://crux-python.cruxinformatics.com/en/latest/authentication.html) documentation for details.
 
 ## Development
 
@@ -45,7 +63,7 @@ Python 3.7 is required for development, which can be installed with `brew instal
 
 ### Multiple Python versions
 
-To be able to run unit tests against all supported Python versions, you must have all supported Python versions installed. The test runner will look for binaries called `python2.7`, `python3.5`, `python3.6`, etc. There are multiple ways to install Python versions, we'll document using [pyenv](https://github.com/pyenv/pyenv).
+To be able to run tests against all supported Python versions, you must have all supported Python versions installed. The test runner will look for binaries called `python2.7`, `python3.5`, `python3.6`, etc. There are multiple ways to install Python versions, we'll document using [pyenv](https://github.com/pyenv/pyenv).
 
 1. `brew install pyenv` to install
 2. Put `eval "$(pyenv init -)"` towards the end of the shell configuration file (~/.bashrc or ~/.bash_profile), because it manipulates `$PATH`, for example:
@@ -64,7 +82,7 @@ To be able to run unit tests against all supported Python versions, you must hav
     ```
 
 5. `pyenv global system 3.5.6 3.6.6 3.7.0` to make all the Python versions available
-6. If you already have pipenv virtual environment, remove it with `pipenv --rm` so it detects the Python version
+6. If you already have pipenv virtual environment, remove it with `pipenv --rm` so it detects the Python versions
 7. `pipenv install --dev` to install all the dependancies
 8. `pipenv shell` to get a shell in the virtual environment
 
@@ -89,11 +107,11 @@ make unit
 nox -s unit
 
 # Run integration tests agains all available Python versions
-export CRUX_API_KEY="12345"
+ export CRUX_API_KEY="12345"
 export CRUX_API_HOST="https://api.example.com"
 make integration
 # Or
-export CRUX_API_KEY="12345"
+ export CRUX_API_KEY="12345"
 export CRUX_API_HOST="https://api.example.com"
 nox --s integration
 

--- a/crux/apis.py
+++ b/crux/apis.py
@@ -166,7 +166,9 @@ class Crux(object):
             .. code-block:: python
 
                 from crux import Crux
-                conn = Crux(api_key="api_key", api_host="https://api-host")
+
+                conn = Crux()
+
                 provenance = {
                     "dataset_id":[
                         {

--- a/crux/models/dataset.py
+++ b/crux/models/dataset.py
@@ -1085,7 +1085,7 @@ class Dataset(CruxModel):
 
                 from crux import Crux
 
-                conn = Crux(api_key="api_key", api_host="https://api-host")
+                conn = Crux()
                 dataset_object = conn.get_dataset(id="dataset_id")
                 predicates=[
                     {"op":"eq","key":"test_label1","val":"test_value1"}

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -2,8 +2,6 @@
 
 The Crux Python Client interacts with the Crux API, which requires an API key. Your API key can be retrieved from your Profile within the [Crux web application](https://app.cruxinformatics.com/).
 
-TODO: Are there organizational API keys?
-
 ## Function arguments
 
 For basic scripts you can set the API key with the `api_key` argument when instantiating the Crux client.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,7 @@ import crux  # noqa: E402
 # -- Project information -----------------------------------------------------
 
 project = u"crux-python"
-copyright = u"2018, Crux Informatics, Inc"
+copyright = u"2019, Crux Informatics, Inc"
 author = u"Crux Informatics, Inc."
 
 # The short X.Y version

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,19 +1,29 @@
 # Crux Python Client
 
-The Crux Python Client, provided as the `crux` Python package, it a way to interact with the Crux platform from Python. It provides functionality such as uploading, downloading, and searching for files.
+A Python library for interacting with the Crux platform.
 
-## Installation (macOS)
+The aim of this client is to be a Pythonic way to use the Crux API reliably. It covers core functionality, such as uploading and downloading files, but does not cover all API functionality. It isn't an SDK.
 
-Install a recent version of Python, and a Python dependency and virtual environment manager:
+Python 3.6+ is recommended. Python 2.7 and 3.5 are supported but deprecated, with support planned for removal in early-2020 and mid-2020 respectively.
+
+**This library is ALPHA.** Breaking changes are expected. Pin to a specific version when using this library, and test upgrades thoroughly.
+
+Source code is available on GitHub at [github.com/cruxinformatics/crux-python](https://github.com/cruxinformatics/crux-python).
+
+## Installation
+
+Install a recent version of Python, and a Python dependency and virtual environment manager like [pipenv](https://pipenv.readthedocs.io/en/latest/). On macOS run:
 
 ```bash
 brew install python
 brew install pipenv
 ```
 
-Install `crux` in a virtual environment, and get a shell in that environment:
+Install `crux` [from PyPI](https://pypi.org/project/crux/) in a virtual environment, and get a shell in that environment:
 
 ```bash
+mkdir -p crux_example
+cd crux_example
 pipenv install "crux==0.0.2"
 pipenv shell
 ```
@@ -22,11 +32,9 @@ pipenv shell
 Create a file, like example.py, and use the `crux` module:
 
 ```python
-import os
-
 from crux import Crux
 
-conn = Crux(api_key="YOUR_API_KEY")
+conn = Crux()
 identity = conn.whoami()
 print("I am", identity.email)
 ```
@@ -34,12 +42,17 @@ print("I am", identity.email)
 Run the script:
 
 ```bash
+HISTCONTROL=ignoreboth
+ export CRUX_API_KEY='YOUR_API_KEY'
 python3 example.py
 ```
 
-## Examples
+See the [installation](installation.md) and [authentication](authentication.md) documentation for details.
 
-Examples for specific topics:
+## Details
+
+Details on specific topics:
+
 - [Installation](installation.md)
 - [Authentication](authentication.md)
 - [Searching](searching.md)

--- a/docs/labels.md
+++ b/docs/labels.md
@@ -6,13 +6,7 @@
 from crux import Crux
 from crux.exceptions import CruxAPIException, CruxClientException
 
-# Set the `CRUX_API_KEY`, `CRUX_API_HOST` environment variables.
-# By default `CRUX_API_HOST` will point to Production environment
 conn = Crux()
-
-# Custom connection attributes can be set via following
-
-conn = Crux(api_key="123456789", api_host="https://api.example.com")
 
 try:
     dataset_object = conn.get_dataset(id="567890")
@@ -32,13 +26,7 @@ except CruxClientException as err:
 from crux import Crux
 from crux.exceptions import CruxAPIException, CruxClientException
 
-# Set the `CRUX_API_KEY`, `CRUX_API_HOST` environment variables.
-# By default `CRUX_API_HOST` will point to Production environment
 conn = Crux()
-
-# Custom connection attributes can be set via following
-
-conn = Crux(api_key="123456789", api_host="https://api.example.com")
 
 try:
     dataset_object = conn.get_dataset(id="567890")
@@ -59,13 +47,7 @@ except CruxClientException as err:
 from crux import Crux
 from crux.exceptions import CruxAPIException, CruxClientException
 
-# Set the `CRUX_API_KEY`, `CRUX_API_HOST` environment variables.
-# By default `CRUX_API_HOST` will point to Production environment
 conn = Crux()
-
-# Custom connection attributes can be set via following
-
-conn = Crux(api_key="123456789", api_host="https://api.example.com")
 
 try:
     dataset_object = conn.get_dataset(id="567890")
@@ -85,13 +67,7 @@ except CruxClientException as err:
 from crux import Crux
 from crux.exceptions import CruxAPIException, CruxClientException
 
-# Set the `CRUX_API_KEY`, `CRUX_API_HOST` environment variables.
-# By default `CRUX_API_HOST` will point to Production environment
 conn = Crux()
-
-# Custom connection attributes can be set via following
-
-conn = Crux(api_key="123456789", api_host="https://api.example.com")
 
 try:
     dataset_object = conn.get_dataset(id="567890")
@@ -117,13 +93,7 @@ except CruxClientException as err:
 from crux import Crux
 from crux.exceptions import CruxAPIException, CruxClientException
 
-# Set the `CRUX_API_KEY`, `CRUX_API_HOST` environment variables.
-# By default `CRUX_API_HOST` will point to Production environment
 conn = Crux()
-
-# Custom connection attributes can be set via following
-
-conn = Crux(api_key="123456789", api_host="https://api.example.com")
 
 try:
     dataset_object = conn.get_dataset(id="567890")
@@ -159,13 +129,7 @@ except CruxClientException as err:
 from crux import Crux
 from crux.exceptions import CruxAPIException, CruxClientException
 
-# Set the `CRUX_API_KEY`, `CRUX_API_HOST` environment variables.
-# By default `CRUX_API_HOST` will point to Production environment
 conn = Crux()
-
-# Custom connection attributes can be set via following
-
-conn = Crux(api_key="123456789", api_host="https://api.example.com")
 
 try:
     dataset_object = conn.get_dataset(id="567890")
@@ -188,13 +152,7 @@ except CruxClientException as err:
 from crux import Crux
 from crux.exceptions import CruxAPIException, CruxClientException
 
-# Set the `CRUX_API_KEY`, `CRUX_API_HOST` environment variables.
-# By default `CRUX_API_HOST` will point to Production environment
 conn = Crux()
-
-# Custom connection attributes can be set via following
-
-conn = Crux(api_key="123456789", api_host="https://api.example.com")
 
 try:
     dataset_object = conn.get_dataset(id="567890")
@@ -219,13 +177,7 @@ except CruxClientException as err:
 from crux import Crux
 from crux.exceptions import CruxAPIException, CruxClientException
 
-# Set the `CRUX_API_KEY`, `CRUX_API_HOST` environment variables.
-# By default `CRUX_API_HOST` will point to Production environment
 conn = Crux()
-
-# Custom connection attributes can be set via following
-
-conn = Crux(api_key="123456789", api_host="https://api.example.com")
 
 try:
     dataset_object = conn.get_dataset(id="567890")


### PR DESCRIPTION
- Update docs so GitHub links to Read the Docs, and Read the Docs links
  to GitHub.
- Make the GitHub README and RTD index similar.
- Add deprecation notice for Python 2.7 and 3.5.
- Update copyright year to 2019.
- Remove most of the documentation that passed `api_key` as an arg, to
  discourage hardcoding credentials into code.

**Test Plan:**

Rendered the docs with `make docs`, looked at them and tested the links.