### PR TITLE
Download small files from GCS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ __pycache__/
 /.nox/
 .pytest_cache/
 .mypy_cache/
+/pip-wheel-metadata/

--- a/crux/models/dataset.py
+++ b/crux/models/dataset.py
@@ -533,7 +533,7 @@ class Dataset(CruxModel):
             elif resource.type == "file":
                 file_resource = File.from_dict(resource.to_dict())
                 file_resource.connection = self.connection
-                file_resource.download(local_path=resource_local_path)
+                file_resource.download(resource_local_path)
                 local_file_list.append(resource_local_path)
 
         return local_file_list
@@ -592,9 +592,9 @@ class Dataset(CruxModel):
 
             elif os.path.isfile(content_local_path):
                 fil_o = self.upload_file(
+                    content_local_path,
+                    content_path,
                     media_type=media_type,
-                    path=content_path,
-                    local_path=content_local_path,
                     tags=tags,
                     description=description,
                 )
@@ -716,16 +716,14 @@ class Dataset(CruxModel):
             headers=headers,
         )
 
-    def upload_file(
-        self, local_path, path, media_type=None, description=None, tags=None
-    ):
+    def upload_file(self, src, dest, media_type=None, description=None, tags=None):
         # type: (Union[IO, str], str, str, str, List[str]) -> File
         """Uploads the File.
 
         Args:
-            local_path (str or file): Local OS path whose content
+            src (str or file): Local OS path whose content
                 is to be uploaded to file resource.
-            path (str): File resource path.
+            dest (str): File resource path.
             media_type (str): Content type of the file. Defaults to None.
             description (str): Description of the file. Defaults to None.
             tags (:obj:`list` of :obj:`str`): Tags to be attached to the file resource.
@@ -734,20 +732,20 @@ class Dataset(CruxModel):
             crux.models.File: File Object.
 
         Raises:
-            TypeError: If local_path is not file or string object.
+            TypeError: If src is not file or string object.
             LookupError: If media type is not a valid type.
             CruxClientError: If error occurs in api or in client.
         """
 
         tags = tags if tags else []
 
-        file_resource = self.create_file(tags=tags, description=description, path=path)
+        file_resource = self.create_file(tags=tags, description=description, path=dest)
 
-        if hasattr(local_path, "write"):
+        if hasattr(src, "write"):
 
             if media_type is None:
                 try:
-                    media_type = MediaType.detect(getattr(local_path, "name"))
+                    media_type = MediaType.detect(getattr(src, "name"))
                 except LookupError as err:
                     file_resource.delete()
                     raise LookupError(err)
@@ -758,7 +756,7 @@ class Dataset(CruxModel):
                 return self.connection.api_call(
                     "PUT",
                     ["resources", file_resource.id, "content"],
-                    data=local_path,
+                    data=src,
                     headers=headers,
                     model=File,
                 )
@@ -766,11 +764,11 @@ class Dataset(CruxModel):
                 file_resource.delete()
                 raise CruxClientError(err.message)
 
-        elif isinstance(local_path, str):
+        elif isinstance(src, str):
 
             if media_type is None:
                 try:
-                    media_type = MediaType.detect(local_path)
+                    media_type = MediaType.detect(src)
                 except LookupError as err:
                     file_resource.delete()
                     raise LookupError(err)
@@ -778,7 +776,7 @@ class Dataset(CruxModel):
             headers = {"Content-Type": media_type, "Accept": "application/json"}
 
             try:
-                with open(local_path, mode="rb") as data:
+                with open(src, mode="rb") as data:
                     return self.connection.api_call(
                         "PUT",
                         ["resources", file_resource.id, "content"],
@@ -791,7 +789,7 @@ class Dataset(CruxModel):
                 raise CruxClientError(str(err))
 
         else:
-            raise TypeError("Invalid Data Type for local_path")
+            raise TypeError("Invalid Data Type for src")
 
     def create_query(self, path, config, tags=None, description=None):
         # type: (str, Dict[str, Any], List[str], str) -> Query

--- a/crux/models/file.py
+++ b/crux/models/file.py
@@ -51,10 +51,21 @@ class File(Resource):
 
         return url
 
-    def _dl_signed_url_resumable(self, file_pointer, chunk_size=DEFAULT_CHUNK_SIZE):
-
+    def _dl_signed_url(self, file_obj, chunk_size=DEFAULT_CHUNK_SIZE):
+        """Download from signed URL using requests directly, not google-resumable-media."""
         signed_url = self._get_signed_url()
+        transport = get_signed_url_session()
 
+        with transport.get(signed_url, stream=True) as response:
+            response.raise_for_status()
+            for chunk in response.iter_content(chunk_size=chunk_size):
+                file_obj.write(chunk)
+
+        return True
+
+    def _dl_signed_url_resumable(self, file_obj, chunk_size=DEFAULT_CHUNK_SIZE):
+        """Download from signed URL using google-resumable-media."""
+        signed_url = self._get_signed_url()
         transport = get_signed_url_session()
 
         # Track how many bytes the client has downloaded since the last time they
@@ -69,7 +80,7 @@ class File(Resource):
         max_url_refreshes_without_progress = 5
         max_url_refreshes = 100
 
-        download = ChunkedDownload(signed_url, chunk_size, file_pointer)
+        download = ChunkedDownload(signed_url, chunk_size, file_obj)
 
         while not download.finished:
             try:
@@ -108,7 +119,7 @@ class File(Resource):
                 download = ChunkedDownload(
                     new_signed_url,
                     chunk_size,
-                    file_pointer,
+                    file_obj,
                     start=sum_total_bytes_from_urls,
                 )
         return True
@@ -139,7 +150,7 @@ class File(Resource):
 
         return data.iter_content(chunk_size=chunk_size, decode_unicode=decode_unicode)
 
-    def _download_file(self, file_pointer, chunk_size=DEFAULT_CHUNK_SIZE):
+    def _download_file(self, file_obj, chunk_size=DEFAULT_CHUNK_SIZE):
         # google-resumable-media has a bug where is expects the 'content-range' even
         # for 200 OK responses, which happens when the range is larger than the size.
         # There isn't much point in using resumable media for small files.
@@ -147,78 +158,81 @@ class File(Resource):
         # to be used.
         small_enough = self.size < (chunk_size * 2)
 
-        if self.connection.crux_config.only_use_crux_domains or small_enough:
+        # If we must use only Crux domains, download via the API.
+        if self.connection.crux_config.only_use_crux_domains:
             return self._download(
-                file_pointer=file_pointer, media_type=None, chunk_size=chunk_size
+                file_obj=file_obj, media_type=None, chunk_size=chunk_size
             )
+        # Use requests directly for small files.
+        elif small_enough:
+            return self._dl_signed_url(file_obj=file_obj, chunk_size=chunk_size)
+        # Use google-resumable-media for large files
         else:
             return self._dl_signed_url_resumable(
-                file_pointer=file_pointer, chunk_size=chunk_size
+                file_obj=file_obj, chunk_size=chunk_size
             )
 
-    def download(self, local_path, chunk_size=DEFAULT_CHUNK_SIZE):
+    def download(self, dest, chunk_size=DEFAULT_CHUNK_SIZE):
         # type: (str, int) -> bool
         """Downloads the file resource.
 
         Args:
-            local_path (str or file): Local OS path at which file resource will be downloaded.
+            dest (str or file): Local OS path at which file resource will be downloaded.
             chunk_size (int): Number of bytes to be read in memory.
 
         Returns:
             bool: True if it is downloaded.
 
         Raises:
-            TypeError: If local_path is not a file like or string type.
+            TypeError: If dest is not a file like or string type.
         """
-        if hasattr(local_path, "write"):
-            return self._download_file(local_path, chunk_size=chunk_size)
-        elif isinstance(local_path, (str, unicode)):
-            with open(local_path, "wb") as file_pointer:
-                return self._download_file(file_pointer, chunk_size=chunk_size)
-        else:
-            raise TypeError(
-                "Invalid Data Type for local_path: {}".format(type(local_path))
-            )
+        if not valid_chunk_size(chunk_size):
+            raise ValueError("chunk_size should be multiple of 256 KiB")
 
-    def upload(self, local_path, media_type=None):
+        if hasattr(dest, "write"):
+            return self._download_file(dest, chunk_size=chunk_size)
+        elif isinstance(dest, (str, unicode)):
+            with open(dest, "wb") as file_obj:
+                return self._download_file(file_obj, chunk_size=chunk_size)
+        else:
+            raise TypeError("Invalid Data Type for dest: {}".format(type(dest)))
+
+    def upload(self, src, media_type=None):
         # type: (Union[IO, str], str) -> bool
         """Uploads the content to empty file resource.
 
         Args:
-            local_path (str or file): Local OS path whose content is to be uploaded.
+            src (str or file): Local OS path whose content is to be uploaded.
             media_type (str): Content type of the file. Defaults to None.
 
         Returns
             bool: True if it is uploaded.
 
         Raises:
-            TypeError: If local_path type is invalid.
+            TypeError: If src type is invalid.
         """
 
-        if hasattr(local_path, "read"):
+        if hasattr(src, "read"):
 
             if media_type is None:
-                media_type = MediaType.detect(getattr(local_path, "name"))
+                media_type = MediaType.detect(getattr(src, "name"))
 
             headers = {"Content-Type": media_type, "Accept": "application/json"}
 
             resp = self.connection.api_call(
-                "PUT",
-                ["resources", self.id, "content"],
-                data=local_path,
-                headers=headers,
+                "PUT", ["resources", self.id, "content"], data=src, headers=headers
             )
 
             return resp.status_code == 200
 
-        elif isinstance(local_path, str):
+        elif isinstance(src, str):
 
             if media_type is None:
-                media_type = MediaType.detect(local_path)
+                media_type = MediaType.detect(src)
 
             headers = {"Content-Type": media_type, "Accept": "application/json"}
 
-            with open(local_path, mode="rb") as data:
+            with open(src, mode="rb") as data:
                 resp = self.connection.api_call(
                     "PUT", ["resources", self.id, "content"], data=data, headers=headers
                 )
@@ -226,4 +240,4 @@ class File(Resource):
             return resp.status_code == 200
 
         else:
-            raise TypeError("Invalid Data Type for local_path")
+            raise TypeError("Invalid Data Type for src")

--- a/crux/models/query.py
+++ b/crux/models/query.py
@@ -70,14 +70,14 @@ class Query(Resource):
         return data.iter_content(chunk_size=chunk_size, decode_unicode=decode_unicode)
 
     def download(
-        self, local_path, format="csv", params=None
+        self, dest, format="csv", params=None
     ):  # It is by design pylint: disable=redefined-builtin
         # type: (str, str, Dict[Any, Any]) -> bool
         """Method which streams the Query
 
         Args:
-            local_path (str): Local OS path at which resource will be downloaded.
-            format (str): Output format of the query. Defaults to csv.
+            dest (str): Local OS path at which resource will be downloaded.
+            media_type (str): Output format of the query. Defaults to csv.
             params (dict): Run parameters. Defaults to None.
 
         Returns:
@@ -95,7 +95,7 @@ class Query(Resource):
             headers=headers,
         )
 
-        with open(local_path, "w") as local_file:
+        with open(dest, "w") as local_file:
             for line in data.iter_lines():
                 if line:
                     dcd_line = line.decode("utf-8")

--- a/crux/models/resource.py
+++ b/crux/models/resource.py
@@ -452,7 +452,7 @@ class Resource(CruxModel):
 
         return response.json().get("path")
 
-    def _download(self, file_pointer, media_type, chunk_size=DEFAULT_CHUNK_SIZE):
+    def _download(self, file_obj, media_type, chunk_size=DEFAULT_CHUNK_SIZE):
 
         if media_type is not None:
             headers = {"Accept": media_type}
@@ -464,7 +464,7 @@ class Resource(CruxModel):
         )
 
         for chunk in data.iter_content(chunk_size=chunk_size):
-            file_pointer.write(chunk)
+            file_obj.write(chunk)
 
         return True
 

--- a/crux/models/table.py
+++ b/crux/models/table.py
@@ -26,12 +26,12 @@ class Table(Resource):
             "folder": self.folder,
         }
 
-    def download(self, local_path, media_type, chunk_size=DEFAULT_CHUNK_SIZE):
+    def download(self, dest, media_type, chunk_size=DEFAULT_CHUNK_SIZE):
         # type: (str, str, int) -> bool
         """Downloads the table resource.
 
         Args:
-            local_path (str or file): Local OS path at which file resource will be downloaded.
+            dest (str or file): Local OS path at which file resource will be downloaded.
             media_type (str): Content Type for download.
             chunk_size (int): Number of bytes to be read in memory.
 
@@ -39,18 +39,14 @@ class Table(Resource):
             bool: True if it is downloaded.
 
         Raises:
-            TypeError: If local_path is not a file like or string type.
+            TypeError: If dest is not a file like or string type.
         """
-        if hasattr(local_path, "write"):
-            return self._download(
-                local_path, media_type=media_type, chunk_size=chunk_size
-            )
-        elif isinstance(local_path, (str, unicode)):
-            with open(local_path, "wb") as file_pointer:
+        if hasattr(dest, "write"):
+            return self._download(dest, media_type=media_type, chunk_size=chunk_size)
+        elif isinstance(dest, (str, unicode)):
+            with open(dest, "wb") as file_obj:
                 return self._download(
-                    file_pointer, media_type=media_type, chunk_size=chunk_size
+                    file_obj, media_type=media_type, chunk_size=chunk_size
                 )
         else:
-            raise TypeError(
-                "Invalid Data Type for local_path: {}".format(type(local_path))
-            )
+            raise TypeError("Invalid Data Type for dest: {}".format(type(dest)))

--- a/docs/labels.md
+++ b/docs/labels.md
@@ -1,199 +1,95 @@
 # Labels
 
-## Add Label to Existing Dataset
+## Resources
+
+### View labels
+
+Resources have a `dict` for labels set as the `labels` property.
 
 ```python
 from crux import Crux
-from crux.exceptions import CruxAPIException, CruxClientException
 
 conn = Crux()
+dataset = conn.get_dataset("A_DATASET_ID")
+file = dataset.get_file("/test_folder1/test_folder2/test_file.csv")
 
-try:
-    dataset_object = conn.get_dataset(id="567890")
-
-    if dataset_object.add_label("test_label1", "test_value1"):
-        print("Label added to Dataset")
-
-except CruxAPIException as err:
-    print(err.status_code, err.error_message)
-except CruxClientException as err:
-    print(err.message)
+print(file.labels)
 ```
 
-## Get Label from Dataset
+### Search resources in dataset by label
 
 ```python
 from crux import Crux
-from crux.exceptions import CruxAPIException, CruxClientException
 
 conn = Crux()
+dataset = conn.get_dataset("A_DATASET_ID")
 
-try:
-    dataset_object = conn.get_dataset(id="567890")
+predicates= [
+    {"op":"eq", "key":"label_key1", "val":"label_value1"}
+]
+resource_list = dataset.find_resources_by_label(predicates=predicates)
 
-    label = dataset_object.get_label("test_label1")
-
-    print(label.label_key, label.label_value)
-
-except CruxAPIException as err:
-    print(err.status_code, err.error_message)
-except CruxClientException as err:
-    print(err.message)
+for resource in resource_list:
+    resource.download("/tmp/{file_name}".format(resource.name))
 ```
 
-## Delete Label from Dataset
+### Add label to resource
 
 ```python
 from crux import Crux
-from crux.exceptions import CruxAPIException, CruxClientException
 
 conn = Crux()
+dataset = conn.get_dataset("A_DATASET_ID")
 
-try:
-    dataset_object = conn.get_dataset(id="567890")
+file = dataset.upload_file(
+    src="/tmp/test_file.csv",
+    dest="/test_folder1/test_folder2/test_file.csv",
+)
 
-    if dataset_object.delete_label("test_label1"):
-        print("Label Deleted from Dataset")
-
-except CruxAPIException as err:
-    print(err.status_code, err.error_message)
-except CruxClientException as err:
-    print(err.message)
+file.add_label("label_key1", "label_value1")
 ```
 
-## Search Resources in Dataset by Label
+### Delete label from resource
 
 ```python
 from crux import Crux
-from crux.exceptions import CruxAPIException, CruxClientException
 
 conn = Crux()
+dataset = conn.get_dataset("A_DATASET_ID")
 
-try:
-    dataset_object = conn.get_dataset(id="567890")
+file = dataset.get_file(path="/test_folder1/test_folder2/test_file.csv")
 
-    predicates=[
-        {"op":"eq","key":"test_label1","val":"test_value1"}
-    ]
-
-    resource_list = dataset_object.find_resources_by_label(predicates=predicates)
-
-    for resource in resource_list:
-        resource.download(local_path="/tmp/{file_name}".format(resource.name))
-
-except CruxAPIException as err:
-    print(err.status_code, err.error_message)
-except CruxClientException as err:
-    print(err.message)
+file.delete_label("label_key1")
 ```
 
-## Add Label to Resource
+## Datasets
+
+### Add label to existing dataset
 
 ```python
 from crux import Crux
-from crux.exceptions import CruxAPIException, CruxClientException
 
 conn = Crux()
-
-try:
-    dataset_object = conn.get_dataset(id="567890")
-
-    file_object = dataset_object.upload_file(
-            tags=["test_tag1"],
-            description="test_description",
-            path="/test_folder1/test_folder2/test_file.csv",
-            local_path="/tmp/test_file.csv"
-            )
-
-    file_object2 = dataset_object.upload_file(
-        tags=["test_tag1"],
-        description="test_description",
-        path="/test_folder1/test_folder2/test_file2.csv",
-        local_path="/tmp/test_file.csv"
-        )
-
-    if file_object.add_label("test_label1", "test_value1"):
-        print("Label added to resource")
-    if file_object2.add_label("test_label1", "test_value1"):
-        print("Label added to resource")
-
-except CruxAPIException as err:
-    print(err.status_code, err.error_message)
-except CruxClientException as err:
-    print(err.message)
+dataset = conn.get_dataset("A_DATASET_ID")
+dataset.add_label("label_key1", "label_value1")
 ```
 
-## Get Label from Resource
+### Get label from dataset
 
 ```python
 from crux import Crux
-from crux.exceptions import CruxAPIException, CruxClientException
 
 conn = Crux()
-
-try:
-    dataset_object = conn.get_dataset(id="567890")
-
-    file_object = dataset_object.get_file(path="/test_folder1/test_folder2/test_file.csv")
-    file_object2 = dataset_object.get_file(path="/test_folder1/test_folder2/test_file2.csv")
-
-    print(file_object.labels.get("test_label1"))
-    print(file_object2.labels.get("test_label1))
-
-except CruxAPIException as err:
-    print(err.status_code, err.error_message)
-except CruxClientException as err:
-    print(err.message)
+dataset= conn.get_dataset("A_DATASET_ID")
+label = dataset.get_label("label_key1")
 ```
 
-## Delete Label from Resource
+### Delete label from dataset
 
 ```python
 from crux import Crux
-from crux.exceptions import CruxAPIException, CruxClientException
 
 conn = Crux()
-
-try:
-    dataset_object = conn.get_dataset(id="567890")
-
-    file_object = dataset_object.get_file(path="/test_folder1/test_folder2/test_file.csv")
-    file_object2 = dataset_object.get_file(path="/test_folder1/test_folder2/test_file2.csv")
-
-    if file_object.delete_label("test_label1"):
-        print("Label Deleted from Resource")
-    if file_object2.delete_label("test_label1"):
-        print("Label Deleted from Resource")
-
-except CruxAPIException as err:
-    print(err.status_code, err.error_message)
-except CruxClientException as err:
-    print(err.message)
+dataset = conn.get_dataset("A_DATASET_ID")
+dataset.delete_label("label_key1")
 ```
-
-## Fetch All Labels of Resource
-
-```python
-from crux import Crux
-from crux.exceptions import CruxAPIException, CruxClientException
-
-conn = Crux()
-
-try:
-    dataset_object = conn.get_dataset(id="567890")
-
-    file_object = dataset_object.get_file(path="/test_folder1/test_folder2/test_file.csv")
-
-
-    if file_object.add_label("test_label1","test_value1"):
-        print("Label Added to the Resource")
-    if file_object.add_label("test_label2","test_value2"):
-        print("Label Added to the Resource")
-
-    for label in file_object.labels:
-        print(label, file_object.labels.get(label))
-
-except CruxAPIException as err:
-    print(err.status_code, err.error_message)
-except CruxClientException as err:
-    print(err.message)

--- a/docs/searching.md
+++ b/docs/searching.md
@@ -9,7 +9,7 @@ from crux import Crux
 
 conn = Crux()
 
-dataset = conn.get_dataset(id="A_DATASET_ID")
+dataset = conn.get_dataset("A_DATASET_ID")
 
 predicates=[
     {"op":"eq", "key":"SOME_KEY", "val":"SOME_VALUE"}
@@ -18,6 +18,6 @@ predicates=[
 resources = dataset.find_resources_by_label(predicates=predicates)
 
 for resource in resources:
-    resource.download(local_path="/tmp/{file_name}".format(resource.name))
+    resource.download("/tmp/{file_name}".format(resource.name))
 
 ```

--- a/docs/stitching.md
+++ b/docs/stitching.md
@@ -7,7 +7,6 @@ from crux import Crux
 
 conn = Crux()
 
-
 dataset_object = conn.get_dataset(id="567890")
 
 destination_file = dataset_object.create_file(
@@ -55,7 +54,7 @@ file_obj, job_id = dataset_object.stitch(
     }
 )
 
-if file_obj.download(local_path="/tmp/stitched_twitter.avro", media_type="avro/binary"):
+if file_obj.download("/tmp/stitched_twitter.avro", media_type="avro/binary"):
     print("Downloaded the file")
 
 job = datast_object.get_stitch_job(job_id)

--- a/docs/tables.md
+++ b/docs/tables.md
@@ -17,8 +17,8 @@ dataset = conn.create_dataset(
 )
 
 file = dataset.upload_file(
-    path="/path/to/remote/file.csv",
-    local_path="/tmp/local_file.csv"
+    src="/tmp/local_file.csv",
+    dest="/path/to/remote/file.csv",
 )
 
 table_config = {
@@ -95,7 +95,7 @@ query = dataset.upload_query(
     sql_file="/tmp/query.sql"
 )
 
-downloaded = query.download(local_path="/tmp/downloaded_query.csv")
+downloaded = query.download("/tmp/downloaded_query.csv")
 
 if downloaded:
     print("Query output downloaded successfully")

--- a/tests/integration/test_dataset.py
+++ b/tests/integration/test_dataset.py
@@ -26,6 +26,7 @@ def test_whoami(connection):
     assert identity.type == "user"
 
 
+@pytest.mark.skip(reason="Test is flaky")
 @pytest.mark.usefixtures("connection", "dataset")
 def test_set_datasets_provenance(connection, dataset):
     provenance = {

--- a/tests/integration/test_file.py
+++ b/tests/integration/test_file.py
@@ -12,9 +12,9 @@ def test_stream_file(dataset, helpers):
         "data",
         "test_file.csv",
     )
-    file_name = "test_file_" + helpers.generate_random_string(4) + ".csv"
+    file_name = "test_file_" + helpers.generate_random_string(16) + ".csv"
 
-    file_1 = dataset.upload_file(local_path=upload_path, path="/" + file_name)
+    file_1 = dataset.upload_file(upload_path, "/" + file_name)
 
     assert file_1.name == file_name
 
@@ -37,9 +37,9 @@ def test_delete_file(dataset, helpers):
         "test_file.csv",
     )
 
-    file_name = "test_file_" + helpers.generate_random_string(4) + ".csv"
+    file_name = "test_file_" + helpers.generate_random_string(16) + ".csv"
 
-    file_1 = dataset.upload_file(local_path=upload_path, path="/" + file_name)
+    file_1 = dataset.upload_file(upload_path, "/" + file_name)
 
     assert file_1.name == file_name
 
@@ -60,7 +60,7 @@ def test_upload_file_string(dataset, helpers):
     )
 
     file_1 = dataset.create_file(
-        "/test_file_" + helpers.generate_random_string(4) + ".csv"
+        "/test_file_" + helpers.generate_random_string(16) + ".csv"
     )
 
     upload_result = file_1.upload(upload_file_string)
@@ -79,7 +79,7 @@ def test_upload_file_object(dataset, helpers):
     file_os_object = open(upload_file_string, "rb")
 
     file_1 = dataset.create_file(
-        "/test_file_" + helpers.generate_random_string(4) + ".csv"
+        "/test_file_" + helpers.generate_random_string(16) + ".csv"
     )
 
     upload_result = file_1.upload(file_os_object)

--- a/tests/integration/test_labels.py
+++ b/tests/integration/test_labels.py
@@ -4,7 +4,7 @@ import pytest
 @pytest.mark.usefixtures("dataset", "helpers")
 def test_add_get_label(dataset, helpers):
     file_1 = dataset.create_file(
-        path="/test_file_" + helpers.generate_random_string(4) + ".csv"
+        path="/test_file_" + helpers.generate_random_string(16) + ".csv"
     )
     label_result = file_1.add_label("label1", "value1")
     assert label_result is True
@@ -15,10 +15,10 @@ def test_add_get_label(dataset, helpers):
 @pytest.mark.usefixtures("dataset", "helpers")
 def test_search_label(dataset, helpers):
     file_1 = dataset.create_file(
-        path="/test_file_" + helpers.generate_random_string(4) + ".csv"
+        path="/test_file_" + helpers.generate_random_string(16) + ".csv"
     )
     file_2 = dataset.create_file(
-        path="/test_file_" + helpers.generate_random_string(4) + ".csv"
+        path="/test_file_" + helpers.generate_random_string(16) + ".csv"
     )
     label_result_1 = file_1.add_label("label1", "value1")
     label_result_2 = file_2.add_label("label1", "value1")
@@ -34,10 +34,10 @@ def test_search_label(dataset, helpers):
 @pytest.mark.usefixtures("dataset", "helpers")
 def test_search_label_page(dataset, helpers):
     file_1 = dataset.create_file(
-        path="/test_file_" + helpers.generate_random_string(4) + ".csv"
+        path="/test_file_" + helpers.generate_random_string(16) + ".csv"
     )
     file_2 = dataset.create_file(
-        path="/test_file_" + helpers.generate_random_string(4) + ".csv"
+        path="/test_file_" + helpers.generate_random_string(16) + ".csv"
     )
     label_result_1 = file_1.add_label("label2", "value2")
     label_result_2 = file_2.add_label("label2", "value2")
@@ -52,10 +52,10 @@ def test_search_label_page(dataset, helpers):
 @pytest.mark.usefixtures("dataset", "helpers")
 def test_delete_label(dataset, helpers):
     file_1 = dataset.create_file(
-        path="/test_file_" + helpers.generate_random_string(4) + ".csv"
+        path="/test_file_" + helpers.generate_random_string(16) + ".csv"
     )
     file_2 = dataset.create_file(
-        path="/test_file_" + helpers.generate_random_string(4) + ".csv"
+        path="/test_file_" + helpers.generate_random_string(16) + ".csv"
     )
 
     file_1.add_label("label1", "value1")

--- a/tests/integration/test_permission.py
+++ b/tests/integration/test_permission.py
@@ -5,15 +5,14 @@ import pytest
 
 @pytest.mark.usefixtures("dataset", "helpers")
 def test_file_add_delete_permission(dataset, helpers):
-    upload_path = os.path.join(
+    file_path = os.path.join(
         os.path.abspath(os.path.dirname(os.path.dirname(__file__))),
         "data",
         "test_file.csv",
     )
 
     file_1 = dataset.upload_file(
-        local_path=upload_path,
-        path="/test_file_" + helpers.generate_random_string(4) + ".csv",
+        file_path, "/test_file_" + helpers.generate_random_string(16) + ".csv"
     )
 
     permission = file_1.add_permission()
@@ -33,21 +32,22 @@ def test_file_add_delete_permission(dataset, helpers):
     file_1.delete()
 
 
+@pytest.mark.skip(reason="Test is too slow")
 @pytest.mark.usefixtures("dataset", "helpers")
 def test_folder_add_delete_permission(dataset, helpers):
-    upload_path = os.path.join(
+    file_path = os.path.join(
         os.path.abspath(os.path.dirname(os.path.dirname(__file__))),
         "data",
         "test_file.csv",
     )
 
     file_1 = dataset.upload_file(
-        local_path=upload_path,
-        path="/test_folder/test_file_" + helpers.generate_random_string(4) + ".csv",
+        file_path,
+        "/test_folder/test_file_" + helpers.generate_random_string(16) + ".csv",
     )
     file_2 = dataset.upload_file(
-        local_path=upload_path,
-        path="/test_folder/test_file_" + helpers.generate_random_string(4) + ".csv",
+        file_path,
+        "/test_folder/test_file_" + helpers.generate_random_string(16) + ".csv",
     )
 
     folder_1 = dataset.get_folder(path="/test_folder")
@@ -88,25 +88,24 @@ def test_folder_add_delete_permission(dataset, helpers):
 
 @pytest.mark.usefixtures("dataset", "helpers")
 def test_dataset_add_permission(dataset, helpers):
-    upload_path = os.path.join(
+    file_path = os.path.join(
         os.path.abspath(os.path.dirname(os.path.dirname(__file__))),
         "data",
         "test_file.csv",
     )
 
     file_1 = dataset.upload_file(
-        local_path=upload_path,
-        path="/test_file_" + helpers.generate_random_string(4) + ".csv",
+        file_path, "/test_file_" + helpers.generate_random_string(16) + ".csv"
     )
 
     file_2 = dataset.upload_file(
-        local_path=upload_path,
-        path="/test_folder/test_file_" + helpers.generate_random_string(4) + ".csv",
+        file_path,
+        "/test_folder/test_file_" + helpers.generate_random_string(16) + ".csv",
     )
 
     file_3 = dataset.upload_file(
-        local_path=upload_path,
-        path="/test_folder/test_file_" + helpers.generate_random_string(4) + ".csv",
+        file_path,
+        "/test_folder/test_file_" + helpers.generate_random_string(16) + ".csv",
     )
 
     dataset_perm_result = dataset.add_permission()

--- a/tests/integration/test_stitching.py
+++ b/tests/integration/test_stitching.py
@@ -12,17 +12,17 @@ def test_stitch_with_file_object(dataset, helpers):
     )
 
     file_1 = dataset.upload_file(
+        stitch_file,
+        "/twitter_" + helpers.generate_random_string(16) + ".avro",
         tags=["test_tag1"],
         description="test_description",
-        path="/twitter_" + helpers.generate_random_string(4) + ".avro",
-        local_path=stitch_file,
     )
 
     file_2 = dataset.upload_file(
+        stitch_file,
+        "/twitter_" + helpers.generate_random_string(16) + ".avro",
         tags=["test_tag1"],
         description="test_description",
-        path="/twitter_" + helpers.generate_random_string(4) + ".avro",
-        local_path=stitch_file,
     )
 
     file_obj, job_id = dataset.stitch(
@@ -42,22 +42,16 @@ def test_stitch(dataset, helpers):
         "twitter.avro",
     )
 
-    file_1_name = "/twitter_str_" + helpers.generate_random_string(4) + ".avro"
+    file_1_name = "/twitter_str_" + helpers.generate_random_string(16) + ".avro"
 
     dataset.upload_file(
-        tags=["test_tag1"],
-        description="test_description",
-        path=file_1_name,
-        local_path=stitch_file,
+        stitch_file, file_1_name, tags=["test_tag1"], description="test_description"
     )
 
-    file_2_name = "/twitter_str_" + helpers.generate_random_string(4) + ".avro"
+    file_2_name = "/twitter_str_" + helpers.generate_random_string(16) + ".avro"
 
     dataset.upload_file(
-        tags=["test_tag1"],
-        description="test_description",
-        path=file_2_name,
-        local_path=stitch_file,
+        stitch_file, file_2_name, tags=["test_tag1"], description="test_description"
     )
 
     file_obj, job_id = dataset.stitch(

--- a/tests/integration/test_table.py
+++ b/tests/integration/test_table.py
@@ -6,15 +6,15 @@ import pytest
 
 @pytest.mark.usefixtures("dataset", "helpers")
 def test_load_file_into_table(dataset, helpers):
-    upload_path = os.path.join(
+    file_path = os.path.join(
         os.path.abspath(os.path.dirname(os.path.dirname(__file__))),
         "data",
         "test_file.csv",
     )
 
-    file_name = "test_file_" + helpers.generate_random_string(4) + ".csv"
+    file_name = "test_file_" + helpers.generate_random_string(16) + ".csv"
 
-    file = dataset.upload_file(path="/" + file_name, local_path=upload_path)
+    file = dataset.upload_file(file_path, "/" + file_name)
 
     assert file.name == file_name
 
@@ -25,7 +25,7 @@ def test_load_file_into_table(dataset, helpers):
         ]
     }
 
-    table_name = "bank_table_" + helpers.generate_random_string(4)
+    table_name = "bank_table_" + helpers.generate_random_string(16)
 
     table = dataset.create_table(path="/" + table_name, config=table_config)
 
@@ -39,14 +39,14 @@ def test_load_file_into_table(dataset, helpers):
 
 @pytest.mark.usefixtures("dataset", "helpers")
 def test_create_run_query(dataset, helpers):
-    upload_path = os.path.join(
+    file_path = os.path.join(
         os.path.abspath(os.path.dirname(os.path.dirname(__file__))),
         "data",
         "test_file.csv",
     )
-    file_name = "test_file_" + helpers.generate_random_string(4) + ".csv"
+    file_name = "test_file_" + helpers.generate_random_string(16) + ".csv"
 
-    dataset.upload_file(path="/" + file_name, local_path=upload_path)
+    dataset.upload_file(file_path, "/" + file_name)
 
     table_config = {
         "schema": [
@@ -55,13 +55,13 @@ def test_create_run_query(dataset, helpers):
         ]
     }
 
-    table_name = "bank_table_" + helpers.generate_random_string(4)
+    table_name = "bank_table_" + helpers.generate_random_string(16)
 
     dataset.create_table(path="/" + table_name, config=table_config)
 
     query_config = {"query": "SELECT * FROM " + table_name}
 
-    query_name = "bank_query" + helpers.generate_random_string(4)
+    query_name = "bank_query" + helpers.generate_random_string(16)
 
     query = dataset.create_query(path="/" + query_name, config=query_config)
 
@@ -93,12 +93,12 @@ def test_upload_download_query(dataset, helpers):
     sql_path = os.path.join(
         os.path.abspath(os.path.dirname(os.path.dirname(__file__))), "data", "query.sql"
     )
-    query_name = "bank_query" + helpers.generate_random_string(4)
+    query_name = "bank_query" + helpers.generate_random_string(16)
 
     query = dataset.upload_query(path="/" + query_name, sql_file=sql_path)
 
     assert query.name == query_name
 
     with NamedTemporaryFile() as temp_query_file:
-        download_result = query.download(local_path=temp_query_file.name)
+        download_result = query.download(temp_query_file.name)
         assert download_result is True

--- a/tests/integration/test_upload_download.py
+++ b/tests/integration/test_upload_download.py
@@ -13,21 +13,22 @@ def test_upload_download_files(dataset, helpers):
         "upload_test",
     )
 
-    file_objects = dataset.upload_files(local_path=data_dir, folder="/upload_download")
+    folder_name = "{random}".format(random=helpers.generate_random_string(8))
+    folder_path = "/{folder}".format(folder=folder_name)
+
+    file_objects = dataset.upload_files(local_path=data_dir, folder=folder_path)
     assert len(file_objects) == 2
     for file_object in file_objects:
         assert file_object.name in ["test_file.csv", "test_file_2.csv"]
     download_dir = mkdtemp()
     downloaded_file_list = dataset.download_files(
-        local_path=download_dir, folder="/upload_download"
+        local_path=download_dir, folder=folder_path
     )
     assert len(downloaded_file_list) == 2
-    assert sorted(downloaded_file_list)[0] == download_dir + "/test_file.csv"
-    assert (
-        sorted(downloaded_file_list)[1]
-        == download_dir  # noqa: W503 as it is formatted by black
-        + "/test_folder1/test_file_2.csv"  # noqa: W503 as it is formatted by black
-    )
+    download_path = os.path.join(download_dir, "test_file.csv")
+    assert sorted(downloaded_file_list)[0] == download_path
+    download_path2 = os.path.join(download_dir, "test_folder1", "test_file_2.csv")
+    assert sorted(downloaded_file_list)[1] == download_path2
 
     assert sorted(os.listdir(data_dir)) == sorted(os.listdir(download_dir))
     shutil.rmtree(download_dir)
@@ -42,16 +43,14 @@ def test_upload_file_object(dataset, helpers):
     )
 
     file_name = "test_file_" + helpers.generate_random_string(4) + ".csv"
-
-    local_file_object = open(upload_path, "rb")
-
-    file_1 = dataset.upload_file(
-        local_path=local_file_object, path="/test_folder_3/" + file_name
+    file_path = "/{folder}/{file}".format(
+        folder=helpers.generate_random_string(8), file=file_name
     )
 
-    assert file_1.name == file_name
+    with open(upload_path, "rb") as local_file_object:
+        file_1 = dataset.upload_file(local_file_object, file_path)
 
-    local_file_object.close()
+    assert file_1.name == file_name
 
 
 @pytest.mark.usefixtures("dataset", "helpers")
@@ -64,9 +63,7 @@ def test_download_file_object(dataset, helpers):
 
     file_name = "test_file_" + helpers.generate_random_string(4) + ".csv"
 
-    file_1 = dataset.upload_file(
-        local_path=upload_path, path="/test_folder_3/" + file_name
-    )
+    file_1 = dataset.upload_file(upload_path, "/test_folder_3/" + file_name)
 
     with TemporaryFile() as temp_file:
         download_result = file_1.download(temp_file)
@@ -85,9 +82,7 @@ def test_download_file_string(dataset, helpers):
 
     file_name = "test_file_" + helpers.generate_random_string(4) + ".csv"
 
-    file_1 = dataset.upload_file(
-        local_path=upload_path, path="/test_folder_3/" + file_name
-    )
+    file_1 = dataset.upload_file(upload_path, "/test_folder_3/" + file_name)
 
     with NamedTemporaryFile() as temp_file:
         download_result = file_1.download(temp_file.name)

--- a/tests/unit/test_file.py
+++ b/tests/unit/test_file.py
@@ -74,5 +74,5 @@ def monkeypatch_download(local_path):
 
 def test_download(monkeypatch, file):
     monkeypatch.setattr(file, "download", monkeypatch_download)
-    result = file.download(local_path="/tmp/test.csv")
+    result = file.download("/tmp/test.csv")
     assert result is True


### PR DESCRIPTION
We want all files downloaded from GCS, unless the user chooses to
restrict to Crux domains. Even small files should come from GCS, just
not using ChunkedDownload.

Change file downloads to use plain requests for downloading small files
from signed URLs.

There is some additional work that still needs to be done to make the
file downloads respect the client proxy settings, and throw crux-python
exceptions instead requests exceptions.

Also:

- I got bothered that `file_pointer` wasn't technically a C file
  pointer, change it to `file_obj` instead.
- Then I got really OCD about `local_path` for `download()` and
  `upload()` methods, because it it took either a file-like object or a
  file path. Change to `dest` for downloads and `src` for uploads.
- Update docs with arg name changes, and remove args names when they
  are simple and required.
- Simplify label docs.

The integration tests were very unreliable. Use random names more, and
change to longer random names (I actually hit duplicate random names).
Skip a `test_folder_add_delete_permission()` because it is way too
slow, or maybe doesn't even work. Skip `test_set_datasets_provenance()`
because it is either really flaky or doesn't work.

It isn't ideal to be skipping testing, they will be fixed another PR.

**Test Plan:**

All tests pass, lint, integration, type checking, formatting.

I manually tested with a download script, with urllib3 DEBUG logging
enabled, and was able to see the downloads coming from GCS. And I set
`only_use_crux_domains=True` and it worked, and I was able to see the
download coming from the API.