### PR TITLE
Make setup.py compatible with Python 2.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 Setup file for Python packaging.
 """
 
+import io
 import os
 
 from setuptools import find_packages, setup
@@ -11,10 +12,10 @@ requirements = ["google-resumable-media[requests]", "typing;python_version<'3.5'
 packages = [pkg for pkg in find_packages() if pkg.startswith("crux")]
 
 version = {}
-with open(os.path.join(here, "crux", "__version__.py"), "r", encoding="utf-8") as fh:
+with io.open(os.path.join(here, "crux", "__version__.py"), "r", encoding="utf-8") as fh:
     exec(fh.read(), version)
 
-with open("README.md", "r", encoding="utf-8") as fh:
+with io.open("README.md", "r", encoding="utf-8") as fh:
     readme = fh.read()
 
 setup(


### PR DESCRIPTION
Python 2.7's built-in open() doesn't support the encoding args. Use
io.open instead, which is what Python 3's built-in open is.

**Test Plan:**

I ran `python2.7 setup.py` to make sure there wasn't a Python error.
Also ran `python3.7 setup.py`.