### PR TITLE
Bump version to 0.0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Install `crux` [from PyPI](https://pypi.org/project/crux/) in a virtual environm
 ```bash
 mkdir -p crux_example
 cd crux_example
-pipenv install "crux==0.0.5"
+pipenv install "crux==0.0.6"
 pipenv shell
 ```
 ## Getting Started

--- a/crux/__version__.py
+++ b/crux/__version__.py
@@ -1,3 +1,3 @@
 """Module contains version and other package information."""
 
-__version__ = "0.0.5"
+__version__ = "0.0.6"

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ Install `crux` [from PyPI](https://pypi.org/project/crux/) in a virtual environm
 ```bash
 mkdir -p crux_example
 cd crux_example
-pipenv install "crux==0.0.5"
+pipenv install "crux==0.0.6"
 pipenv shell
 ```
 ## Getting Started

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -17,13 +17,13 @@ See the [Pipenv installation instructions](https://pipenv.readthedocs.io/en/late
 Once Pipenv is installed, change into the root of your application directory and run:
 
 ```bash
-pipenv install "crux==0.0.5"
+pipenv install "crux==0.0.6"
 ```
 
 This will add a line to the `[packages]` section of your Pipfile, or create a new Pipfile if one doesn't exist.
 
 ```ini
-crux = "==0.0.5"
+crux = "==0.0.6"
 ```
 
 ## With venv and pip
@@ -33,6 +33,6 @@ Alternatively you can create a virtual environment with Python 3's [venv module]
 ```bash
 python3 -m venv .venv
 source .venv/bin/activate
-python3 -m pip install "crux==0.0.5"
+python3 -m pip install "crux==0.0.6"
 python3 -m pip freeze > requirements.txt
 ```


### PR DESCRIPTION
BREAKING CHANGES:

- Change `Dataset.add_permission()` to set dataset permissions, add
  `Dataset.add_permission_to_resources()` for bulk resource permission
  updates.

Changes:

- Reuse request session to allow TCP connection to be reused.
- Add `Crux.close()` to close session, for uses that create many `Crux`
  clients.
- Support proxies signed GCS uploads/downloads.
- enum34 no longer vendored.