### PR TITLE
Add Crux.get_resource()

### DIFF
--- a/docs/downloading.md
+++ b/docs/downloading.md
@@ -16,6 +16,19 @@ file = dataset.get_file("/path/to/file.csv")
 file.download("/tmp/file.csv")
 ```
 
+## Use resource ID to download file
+
+Crux files have a resource ID (accessible with `File.id`). That resource ID can be used to get a `File` object. Getting files by resource ID is more efficient than getting them by path.
+
+```python
+from crux import Crux
+
+conn = Crux()
+
+file = conn.get_resource("A_CRUX_FILE_RESOURCE_ID)
+file.download("/tmp/file.csv")
+```
+
 ## Download streaming chunks
 
 Download a file in chunks of bytes, for example to stream out while downloading.

--- a/docs/downloading.md
+++ b/docs/downloading.md
@@ -25,7 +25,7 @@ from crux import Crux
 
 conn = Crux()
 
-file = conn.get_resource("A_CRUX_FILE_RESOURCE_ID)
+file = conn.get_resource("A_CRUX_FILE_RESOURCE_ID")
 file.download("/tmp/file.csv")
 ```
 

--- a/tests/integration/test_file.py
+++ b/tests/integration/test_file.py
@@ -3,6 +3,7 @@ import os
 import pytest
 
 from crux.exceptions import CruxResourceNotFoundError
+from crux.models import File
 
 
 @pytest.mark.usefixtures("dataset_with_crux_domain", "helpers")
@@ -104,8 +105,8 @@ def test_upload_file_string(dataset, helpers):
     assert uploaded_object.name == file_1.name
 
 
-@pytest.mark.usefixtures("dataset", "helpers")
-def test_upload_file_object(dataset, helpers):
+@pytest.mark.usefixtures("connection", "dataset", "helpers")
+def test_upload_file_object(connection, dataset, helpers):
     upload_file_string = os.path.join(
         os.path.abspath(os.path.dirname(os.path.dirname(__file__))),
         "data",
@@ -120,4 +121,10 @@ def test_upload_file_object(dataset, helpers):
 
     uploaded_object = file_1.upload(file_os_object)
 
+    # Test that resources can be fetched by ID
+    file_from_id = connection.get_resource(file_1.id)
+
     assert uploaded_object.name == file_1.name
+    assert isinstance(file_from_id, File)
+    assert file_from_id.id == file_1.id
+    assert file_from_id.size == file_1.size


### PR DESCRIPTION
Sometimes users only have a resource ID and they need to get a full
resource object. Or they have a path and ID, but prefer the more
efficient get by ID.

Add the method `Crux.get_resource()` to get a resource by ID. Resource
IDs are global, not specific to datasets, so the method is directly on
the main `Crux` client.

**Test Plan:**

Unit and integration tests have been written and pass. Lint and format
checks pass. The integration test is realistic enough that I don't plan
on doing any other testing.

```
$ make test
...
nox > Ran multiple sessions:
nox > * lint-3.7: success
nox > * unit-2.7: success
nox > * unit-3.5: success
nox > * unit-3.6: success
nox > * unit-3.7: success
nox > * integration-2.7: success
nox > * integration-3.5: success
nox > * integration-3.6: success
nox > * integration-3.7: success
nox > * format_check-3.7: success
nox > * type_check-3.7: success
```