### PR TITLE
Avoid using compiled regex

### DIFF
--- a/crux/_config.py
+++ b/crux/_config.py
@@ -47,8 +47,8 @@ class CruxConfig(object):
         Raises:
             ValueError: If CRUX_API_KEY is not set.
         """
-        self.re_user_agent_banned_chars = re.compile(r"[^a-zA-Z0-9._+~-]")
-        self.re_whitespace_runs = re.compile(r"\s+")
+        self.re_user_agent_banned_chars = "[^a-zA-Z0-9._+~-]"
+        self.re_whitespace_runs = "\s+"
 
         if api_key is None:
             if "CRUX_API_KEY" in os.environ:
@@ -146,8 +146,8 @@ class CruxConfig(object):
     def _sanitize_user_agent_part(self, part):
         # type: (str) -> str
         if part:
-            no_space_part = self.re_whitespace_runs.sub("_", part)
-            sanitized_part = self.re_user_agent_banned_chars.sub("", no_space_part)
+            no_space_part = re.sub(self.re_whitespace_runs, "_", part)
+            sanitized_part = re.sub(self.re_user_agent_banned_chars, "", no_space_part)
             if sanitized_part:
                 return sanitized_part
         return "unknown"

--- a/crux/_config.py
+++ b/crux/_config.py
@@ -47,9 +47,6 @@ class CruxConfig(object):
         Raises:
             ValueError: If CRUX_API_KEY is not set.
         """
-        self.re_user_agent_banned_chars = "[^a-zA-Z0-9._+~-]"
-        self.re_whitespace_runs = "\s+"
-
         if api_key is None:
             if "CRUX_API_KEY" in os.environ:
                 log.debug("Fetching API KEY from OS Environment Variable")
@@ -146,8 +143,8 @@ class CruxConfig(object):
     def _sanitize_user_agent_part(self, part):
         # type: (str) -> str
         if part:
-            no_space_part = re.sub(self.re_whitespace_runs, "_", part)
-            sanitized_part = re.sub(self.re_user_agent_banned_chars, "", no_space_part)
+            no_space_part = re.sub(r"\s+", "_", part)
+            sanitized_part = re.sub(r"[^a-zA-Z0-9._+~-]", "", no_space_part)
             if sanitized_part:
                 return sanitized_part
         return "unknown"

--- a/tests/unit/test_apis.py
+++ b/tests/unit/test_apis.py
@@ -196,3 +196,8 @@ def test_get_resource(monkeypatch, monkey_conn):
     resource = monkey_conn.get_resource("UNIT_TEST_RESOURCE_ID")
     assert isinstance(resource, File)
     assert resource.id == "UNIT_TEST_RESOURCE_ID"
+
+def test_deepcopy(monkey_conn):
+    import copy
+    monkey_copy = copy.deepcopy(monkey_conn)
+    assert type(monkey_conn) == type(monkey_copy)

--- a/tests/unit/test_apis.py
+++ b/tests/unit/test_apis.py
@@ -1,5 +1,5 @@
 import os
-
+import copy
 import pytest
 
 from crux import Crux
@@ -198,6 +198,5 @@ def test_get_resource(monkeypatch, monkey_conn):
     assert resource.id == "UNIT_TEST_RESOURCE_ID"
 
 def test_deepcopy(monkey_conn):
-    import copy
     monkey_copy = copy.deepcopy(monkey_conn)
     assert type(monkey_conn) == type(monkey_copy)


### PR DESCRIPTION
Change Log:

1) Remove compiled regex from Crux Config instead use strings
2) Add Unit test to verify deep copy succeeds particularly with Python 3.6.6