### PR TITLE
Added raise_for_status for direct download

### DIFF
--- a/crux/_client.py
+++ b/crux/_client.py
@@ -134,7 +134,7 @@ class CruxClient(object):
                     timeout=(connect_timeout, read_timeout),
                 )
             except (HTTPError, TooManyRedirects) as err:
-                raise CruxClientHTTPError(str(err))
+                raise CruxClientHTTPError(str(err), err.response)
             except (ProxyError, SSLError) as err:
                 raise CruxClientConnectionError(str(err))
             except (ConnectTimeout, ReadTimeout) as err:

--- a/crux/_client.py
+++ b/crux/_client.py
@@ -27,6 +27,7 @@ from crux.exceptions import (
     CruxClientConnectionError,
     CruxClientHTTPError,
     CruxClientTimeout,
+    CruxClientTooManyRedirects,
     CruxResourceNotFoundError,
 )
 
@@ -133,8 +134,10 @@ class CruxClient(object):
                     params=params,
                     timeout=(connect_timeout, read_timeout),
                 )
-            except (HTTPError, TooManyRedirects) as err:
+            except HTTPError as err:
                 raise CruxClientHTTPError(str(err), err.response)
+            except TooManyRedirects as err:
+                raise CruxClientTooManyRedirects(str(err))
             except (ProxyError, SSLError) as err:
                 raise CruxClientConnectionError(str(err))
             except (ConnectTimeout, ReadTimeout) as err:

--- a/crux/_config.py
+++ b/crux/_config.py
@@ -140,7 +140,7 @@ class CruxConfig(object):
 
         return user_agent
 
-    def _sanitize_user_agent_part(self, part):
+    def _sanitize_user_agent_part(self, part):  # pylint: disable=no-self-use
         # type: (str) -> str
         if part:
             no_space_part = re.sub(r"\s+", "_", part)

--- a/crux/exceptions.py
+++ b/crux/exceptions.py
@@ -67,6 +67,13 @@ class CruxClientHTTPError(CruxClientError):
         return "{message}".format(message=self.message)
 
 
+class CruxClientTooManyRedirects(CruxClientError):
+    """Exception should be raised when SDK gets too many redirects."""
+
+    def __str__(self):
+        return "{message}".format(message=self.message)
+
+
 class CruxClientConnectionError(CruxClientError):
     """Exception should be raised when SDK expects any connection related errors."""
 

--- a/crux/exceptions.py
+++ b/crux/exceptions.py
@@ -2,6 +2,8 @@
 
 from typing import Dict, Union  # noqa: F401
 
+import requests  # pylint: disable=unused-import
+
 
 class CruxAPIError(Exception):
     """Exception which should be raised when the API response expects an error."""
@@ -45,6 +47,21 @@ class CruxClientError(Exception):
 
 class CruxClientHTTPError(CruxClientError):
     """Exception should be raised when SDK expects any HTTP related errors."""
+
+    def __init__(self, message, response):
+        # type: (str, requests.Response) -> None
+        """
+        Args:
+            message (str): Human readable string describing the exception.
+            response (requests.Response): Response object.
+
+        Attributes:
+            message (str): Human readable string describing the exception.
+            response (requests.Response): Response object.
+        """
+        super(CruxClientHTTPError, self).__init__(message)
+        self.message = message
+        self.response = response
 
     def __str__(self):
         return "{message}".format(message=self.message)

--- a/crux/models/file.py
+++ b/crux/models/file.py
@@ -88,10 +88,11 @@ class File(Resource):
         try:
             with transport as session:
                 response = session.get(signed_url, stream=True)
+                response.raise_for_status()
                 for chunk in response.iter_content(chunk_size=chunk_size):
                     file_obj.write(chunk)
         except (HTTPError, TooManyRedirects) as err:
-            raise CruxClientHTTPError(str(err))
+            raise CruxClientHTTPError(str(err), err.response)
         except (ProxyError, SSLError) as err:
             raise CruxClientConnectionError(str(err))
         except (ConnectTimeout, ReadTimeout) as err:

--- a/crux/models/file.py
+++ b/crux/models/file.py
@@ -33,6 +33,7 @@ from crux.exceptions import (
     CruxClientError,
     CruxClientHTTPError,
     CruxClientTimeout,
+    CruxClientTooManyRedirects,
 )
 from crux.models.resource import MediaType, Resource
 
@@ -91,8 +92,10 @@ class File(Resource):
                 response.raise_for_status()
                 for chunk in response.iter_content(chunk_size=chunk_size):
                     file_obj.write(chunk)
-        except (HTTPError, TooManyRedirects) as err:
+        except HTTPError as err:
             raise CruxClientHTTPError(str(err), err.response)
+        except TooManyRedirects as err:
+            raise CruxClientTooManyRedirects(str(err))
         except (ProxyError, SSLError) as err:
             raise CruxClientConnectionError(str(err))
         except (ConnectTimeout, ReadTimeout) as err:

--- a/docs/exception_handling.md
+++ b/docs/exception_handling.md
@@ -23,6 +23,10 @@ The `crux` client will raise exceptions when errors are encountered. There are t
 
 `CruxClientHTTPError` is raised when client encounters HTTP related errors.
 
+## CruxClientTooManyRedirects
+
+`CruxClientTooManyRedirects` is raised when client encounters too many redirects.
+
 ## CruxClientConnectionError
 
 `CruxClientConnectionError` is raised when client encounters Proxy and SSL related errors.

--- a/tests/unit/test_apis.py
+++ b/tests/unit/test_apis.py
@@ -1,5 +1,6 @@
-import os
 import copy
+import os
+
 import pytest
 
 from crux import Crux
@@ -196,6 +197,7 @@ def test_get_resource(monkeypatch, monkey_conn):
     resource = monkey_conn.get_resource("UNIT_TEST_RESOURCE_ID")
     assert isinstance(resource, File)
     assert resource.id == "UNIT_TEST_RESOURCE_ID"
+
 
 def test_deepcopy(monkey_conn):
     monkey_copy = copy.deepcopy(monkey_conn)

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -259,7 +259,9 @@ def monkeypatch_client_http_exception(
     proxies=None,
     timeout=None,
 ):
-    raise HTTPError("Test HTTP Error")
+    response = Response()
+    response.status_code = 404
+    raise HTTPError("Test HTTP Error", response=response)
 
 
 def test_client_http_exception(client, monkeypatch):
@@ -267,8 +269,9 @@ def test_client_http_exception(client, monkeypatch):
         requests.sessions.Session, "request", monkeypatch_client_http_exception
     )
 
-    with pytest.raises(CruxClientHTTPError):
+    with pytest.raises(CruxClientHTTPError) as http_error:
         client.api_call(method="GET", path=["test-path"], model=SampleModel)
+    assert http_error.value.response.status_code == 404
 
 
 def monkeypatch_test_client_proxy_exception(
@@ -383,7 +386,9 @@ def monkeypatch_test_too_many_redirects_exception(
     proxies=None,
     timeout=None,
 ):
-    raise TooManyRedirects("Test Connect Timeout Error")
+    response = Response()
+    response.status_code = 301
+    raise TooManyRedirects("Test Connect Timeout Error", response=response)
 
 
 def test_client_too_many_redirects_exception(client, monkeypatch):
@@ -393,5 +398,6 @@ def test_client_too_many_redirects_exception(client, monkeypatch):
         monkeypatch_test_too_many_redirects_exception,
     )
 
-    with pytest.raises(CruxClientHTTPError):
+    with pytest.raises(CruxClientHTTPError) as redirect_error:
         client.api_call(method="GET", path=["test-path"], model=SampleModel)
+    assert redirect_error.value.response.status_code == 301

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -18,6 +18,7 @@ from crux.exceptions import (
     CruxClientConnectionError,
     CruxClientHTTPError,
     CruxClientTimeout,
+    CruxClientTooManyRedirects,
 )
 from crux.models.model import CruxModel
 
@@ -386,9 +387,7 @@ def monkeypatch_test_too_many_redirects_exception(
     proxies=None,
     timeout=None,
 ):
-    response = Response()
-    response.status_code = 301
-    raise TooManyRedirects("Test Connect Timeout Error", response=response)
+    raise TooManyRedirects("Test Connect Timeout Error")
 
 
 def test_client_too_many_redirects_exception(client, monkeypatch):
@@ -398,6 +397,5 @@ def test_client_too_many_redirects_exception(client, monkeypatch):
         monkeypatch_test_too_many_redirects_exception,
     )
 
-    with pytest.raises(CruxClientHTTPError) as redirect_error:
+    with pytest.raises(CruxClientTooManyRedirects):
         client.api_call(method="GET", path=["test-path"], model=SampleModel)
-    assert redirect_error.value.response.status_code == 301

--- a/tests/unit/test_resource.py
+++ b/tests/unit/test_resource.py
@@ -125,8 +125,10 @@ def monkeypatch_update_resource(*args, **kwargs):
 def test_update_resource(resource, monkeypatch):
     monkeypatch.setattr(resource.connection, "api_call", monkeypatch_update_resource)
     update_result = resource.update(
-        name="test_dataset1", description="test_description", tags=["tag1"], 
-        provenance='{"raw_resource_id": ["resource_id1", "resource_id2"]}'
+        name="test_dataset1",
+        description="test_description",
+        tags=["tag1"],
+        provenance='{"raw_resource_id": ["resource_id1", "resource_id2"]}',
     )
     assert update_result is True
 


### PR DESCRIPTION
- Added raise_for_status for file download.
- Refactored code as per errors from linters.
- Refactored CruxClientHTTPError to include response object.
- Refactored unit tests as per the changes.

## Verification

- `make lint`, `make format` worked as per expectation
- `make integration` worked as per expectation except for dataset deletion/cleanup issue.
- Simulated the behavior via following sample.

```python
>>> import requests
>>> from crux.exceptions import CruxClientHTTPError
>>> 
>>> try:
...     r = requests.get('http://httpbin.org/status/404')
...     r.raise_for_status()
... except requests.HTTPError as e:
...     try:
...             raise CruxClientHTTPError(e, e.response)
...     except CruxClientHTTPError as ce:
...             print("CE: {} Status code: {}".format(ce, ce.response.status_code))
... 
CE: 404 Client Error: NOT FOUND for url: http://httpbin.org/status/404 Status code: 404
```