### PR TITLE
Default folder to root if not provided

### DIFF
--- a/crux/_utils.py
+++ b/crux/_utils.py
@@ -90,6 +90,10 @@ def split_posixpath_filename_dirpath(path):
 
     filename = posixpath.basename(path)  # type: str
     dirpath = posixpath.dirname(path)  # type: str
+
+    if not dirpath:
+        dirpath = "/"
+
     return filename, dirpath
 
 


### PR DESCRIPTION
- Fixed an issue where if crux location is specified without "/", it will crash.

## Tests

* Ran `lint`, `unit` and `integration` tests. All of them passed

```bash

# lint

nox > Session lint-3.7 was successful.
nox > Session type_check-3.7 was successful.

# Unit

nox > Session unit-3.7 was successful.
nox > Ran multiple sessions:
nox > * unit-2.7: success
nox > * unit-3.5: skipped
nox > * unit-3.6: success
nox > * unit-3.7: success

# Integration

nox > Session integration-3.7 was successful.
nox > Ran multiple sessions:
nox > * integration-2.7: success
nox > * integration-3.5: skipped
nox > * integration-3.6: success
nox > * integration-3.7: success
```

# Verification

```python
>>> from crux import Crux
>>> conn = Crux()
>>> do = conn.create_dataset("test_123456789")
>>> fo = do.upload_file("/tmp/test.csv", "test.csv")
>>> fo.folder
'/'
```