### PR TITLE
[Stream Support]: Added streaming support from GCS for file resource.

### DIFF
--- a/crux/models/file.py
+++ b/crux/models/file.py
@@ -219,7 +219,11 @@ class File(Resource):
             raise ValueError("chunk_size should be multiple of 256 KiB")
 
         # If we must use only Crux domains, download via the API.
+        if only_use_crux_domains is None:
+            only_use_crux_domains = self.connection.crux_config.only_use_crux_domains
+
         if only_use_crux_domains:
+
             log.debug("Using Crux Domain for streaming file resource %s", self.id)
             data = self.connection.api_call(
                 "GET", ["resources", self.id, "content"], headers=headers, stream=True

--- a/docs/downloading.md
+++ b/docs/downloading.md
@@ -31,7 +31,7 @@ file.download("/tmp/file.csv")
 
 ## Download streaming chunks
 
-Download a file in chunks of bytes, for example to stream out while downloading from Google Storage.
+Download a file in chunks of bytes, for example to stream out while downloading.
 
 ```python
 from crux import Crux
@@ -42,25 +42,6 @@ dataset = conn.get_dataset(id="A_DATASET_ID")
 file = dataset.get_file(path="/path/to/file.csv")
 ten_mb = 10 * 1024 * 1024
 stream = file.iter_content(chunk_size=ten_mb)
-try:
-    with open("/tmp/save", "wb") as fh:
-        for chunk in stream:
-            fh.write(chunk)
-finally:
-    stream.close()
-```
-
-Download a file in chunks of bytes, for example to stream out while downloading from Crux domain.
-
-```python
-from crux import Crux
-
-conn = Crux()
-
-dataset = conn.get_dataset(id="A_DATASET_ID")
-file = dataset.get_file(path="/path/to/file.csv")
-ten_mb = 10 * 1024 * 1024
-stream = file.iter_content(chunk_size=ten_mb, only_use_crux_domains=True)
 try:
     with open("/tmp/save", "wb") as fh:
         for chunk in stream:

--- a/docs/downloading.md
+++ b/docs/downloading.md
@@ -31,7 +31,7 @@ file.download("/tmp/file.csv")
 
 ## Download streaming chunks
 
-Download a file in chunks of bytes, for example to stream out while downloading.
+Download a file in chunks of bytes, for example to stream out while downloading from Google Storage.
 
 ```python
 from crux import Crux
@@ -42,6 +42,25 @@ dataset = conn.get_dataset(id="A_DATASET_ID")
 file = dataset.get_file(path="/path/to/file.csv")
 ten_mb = 10 * 1024 * 1024
 stream = file.iter_content(chunk_size=ten_mb)
+try:
+    with open("/tmp/save", "wb") as fh:
+        for chunk in stream:
+            fh.write(chunk)
+finally:
+    stream.close()
+```
+
+Download a file in chunks of bytes, for example to stream out while downloading from Crux domain.
+
+```python
+from crux import Crux
+
+conn = Crux()
+
+dataset = conn.get_dataset(id="A_DATASET_ID")
+file = dataset.get_file(path="/path/to/file.csv")
+ten_mb = 10 * 1024 * 1024
+stream = file.iter_content(chunk_size=ten_mb, only_use_crux_domains=True)
 try:
     with open("/tmp/save", "wb") as fh:
         for chunk in stream:


### PR DESCRIPTION
- Updated `iter_content()` method to allow streaming from GCS.
- Updated the documentation.

## Verification

* make test, lint and integration works.

## Testing

* Uploaded a sample with size > 5 MB.
* Streamed via `iter_content()` to local temporary file.
* Verified the consistency via md5 checksum.
