### PR TITLE
[0.0.12]: Fixes for crux configuration

### DIFF
--- a/crux/_client.py
+++ b/crux/_client.py
@@ -154,15 +154,13 @@ class CruxClient(object):
                     log.debug("Response is list of type %s", model)
                     serial_list = []
                     for item in response.json():
-                        obj = model.from_dict(item)
-                        obj.connection = self
+                        obj = model.from_dict(item, connection=self)
                         serial_list.append(obj)
                     return serial_list
 
                 else:
                     log.debug("Response is of type %s", model)
-                    obj = model.from_dict(response.json())
-                    obj.connection = self
+                    obj = model.from_dict(response.json(), connection=self)
                     return obj
         elif response.status_code == 204:
             log.debug("Response code is 204, returning True boolean value")

--- a/crux/apis.py
+++ b/crux/apis.py
@@ -109,9 +109,10 @@ class Crux(object):
         raw_resource = response.json()
 
         resource = get_resource_object(
-            resource_type=raw_resource.get("type"), data=raw_resource
+            resource_type=raw_resource.get("type"),
+            data=raw_resource,
+            connection=self.api_client,
         )
-        resource.connection = self.api_client
         return resource
 
     def _call_drives_my(self):
@@ -141,12 +142,12 @@ class Crux(object):
 
         if owned:
             for dataset in datasets["owned"]:
-                obj = Dataset.from_dict(dataset)
+                obj = Dataset.from_dict(dataset, connection=self.api_client)
                 dataset_list.append(obj)
 
         if subscribed:
             for dataset in datasets["subscriptions"]:
-                obj = Dataset.from_dict(dataset)
+                obj = Dataset.from_dict(dataset, connection=self.api_client)
                 dataset_list.append(obj)
 
         return dataset_list

--- a/crux/models/_factory.py
+++ b/crux/models/_factory.py
@@ -2,17 +2,19 @@
 
 from typing import Any, Dict, Union  # noqa: F401
 
+from crux._client import CruxClient
 from crux.models.file import File
 from crux.models.folder import Folder
 
 
-def get_resource_object(resource_type, data):
-    # type: (str, Dict[str, Any]) -> Union[File, Folder]
+def get_resource_object(resource_type, data, connection=None):
+    # type: (str, Dict[str, Any], CruxClient) -> Union[File, Folder]
     """Creates resource object based on its type.
 
     Args:
         resource_type (str): Type of resource which needs to be created.
         data (dict): Dictionary which contains serialized resource data.
+        connection (CruxClient): Connection Object. Defaults to None.
 
     Returns:
         crux.models.Resource: Resource or its Child Object.
@@ -21,8 +23,8 @@ def get_resource_object(resource_type, data):
         TypeError: If it is unable to detect resource type.
     """
     if resource_type == "file":
-        return File.from_dict(data)
+        return File.from_dict(data, connection=connection)
     elif resource_type == "folder":
-        return Folder.from_dict(data)
+        return Folder.from_dict(data, connection=connection)
     else:
         raise TypeError("Invalid Resource Type")

--- a/crux/models/identity.py
+++ b/crux/models/identity.py
@@ -21,7 +21,7 @@ class Identity(CruxModel):
         """
         self.raw_model = raw_model if raw_model is not None else {}
         self.connection = (
-            connection if connection is not None else CruxClient(CruxConfig())
+            connection if connection is not None else CruxClient(CruxConfig(api_key=""))
         )
 
     @property
@@ -130,14 +130,14 @@ class Identity(CruxModel):
         return self.raw_model
 
     @classmethod
-    def from_dict(cls, a_dict):
-        # type: (Dict[str, str]) -> Identity
+    def from_dict(cls, a_dict, connection=None):
+        # type: (Dict[str, str], CruxClient) -> Identity
         """Transforms Identity Dictionary to Identity object.
 
         Args:
             a_dict (dict): Identity Dictionary.
-
+            connection (CruxClient): Connection Object. Defaults to None.
         Returns:
             crux.models.Identity: Identity Object.
         """
-        return cls(raw_model=a_dict)
+        return cls(raw_model=a_dict, connection=connection)

--- a/crux/models/job.py
+++ b/crux/models/job.py
@@ -2,6 +2,8 @@
 
 from typing import Dict  # noqa: F401
 
+from crux._client import CruxClient
+from crux._config import CruxConfig
 from crux.models.model import CruxModel
 
 
@@ -12,13 +14,17 @@ class AbstractJob(CruxModel):
 class Job(AbstractJob):
     """Job Model."""
 
-    def __init__(self, raw_model=None):
-        # type: (Dict) -> None
+    def __init__(self, raw_model=None, connection=None):
+        # type: (Dict, CruxClient) -> None
         """
         Attributes:
             raw_model (dict): Identity raw dictionary. Defaults to None.
+            connection (CruxClient): Connection Object. Defaults to None.
         """
         self.raw_model = raw_model if raw_model is not None else {}
+        self.connection = (
+            connection if connection is not None else CruxClient(CruxConfig(api_key=""))
+        )
 
     @property
     def job_id(self):
@@ -36,29 +42,34 @@ class Job(AbstractJob):
         return self.raw_model["statistics"]
 
     @classmethod
-    def from_dict(cls, a_dict):
-        # type: (Dict[str, str]) -> Job
+    def from_dict(cls, a_dict, connection=None):
+        # type: (Dict[str, str], CruxClient) -> Job
         """Transforms Job Dictionary to Job object.
 
         Args:
             a_dict (dict): Job Dictionary.
+            connection (CruxClient): Connection Object. Defaults to None.
 
         Returns:
             crux.models.Job: Job Object.
         """
-        return cls(raw_model=a_dict)
+        return cls(raw_model=a_dict, connection=connection)
 
 
 class StitchJob(AbstractJob):
     """Stitch Job Model."""
 
-    def __init__(self, raw_model=None):
-        # type: (Dict) -> None
+    def __init__(self, raw_model=None, connection=None):
+        # type: (Dict, CruxClient) -> None
         """
         Attributes:
             raw_model (dict): Identity raw dictionary. Defaults to None.
+            connection (CruxClient): Connection Object. Defaults to None.
         """
         self.raw_model = raw_model if raw_model is not None else {}
+        self.connection = (
+            connection if connection is not None else CruxClient(CruxConfig(api_key=""))
+        )
 
     @property
     def job_id(self):
@@ -71,14 +82,15 @@ class StitchJob(AbstractJob):
         return self.raw_model["status"]
 
     @classmethod
-    def from_dict(cls, a_dict):
-        # type: (Dict[str, str]) -> StitchJob
+    def from_dict(cls, a_dict, connection=None):
+        # type: (Dict[str, str], CruxClient) -> StitchJob
         """Transforms Stitch Job Dictionary to Stitch Job object.
 
         Args:
             a_dict (dict): Stitch Job Dictionary.
+            connection (CruxClient): Connection Object. Defaults to None.
 
         Returns:
             crux.models.job.StitchJob: Stitch Job Object.
         """
-        return cls(raw_model=a_dict)
+        return cls(raw_model=a_dict, connection=connection)

--- a/crux/models/label.py
+++ b/crux/models/label.py
@@ -2,19 +2,25 @@
 
 from typing import Any, Dict
 
+from crux._client import CruxClient
+from crux._config import CruxConfig
 from crux.models.model import CruxModel
 
 
 class Label(CruxModel):
     """Label Model."""
 
-    def __init__(self, raw_model=None):
-        # type: (Dict) -> None
+    def __init__(self, raw_model=None, connection=None):
+        # type: (Dict, CruxClient) -> None
         """
         Attributes:
             raw_model (dict): Identity raw dictionary. Defaults to None.
+            connection (CruxClient): Connection Object. Defaults to None.
         """
         self.raw_model = raw_model if raw_model is not None else {}
+        self.connection = (
+            connection if connection is not None else CruxClient(CruxConfig(api_key=""))
+        )
 
     @property
     def label_key(self):
@@ -36,14 +42,15 @@ class Label(CruxModel):
         return self.raw_model
 
     @classmethod
-    def from_dict(cls, a_dict):
-        # type: (Dict[str,str]) -> Label
+    def from_dict(cls, a_dict, connection=None):
+        # type: (Dict[str,str], CruxClient) -> Label
         """Transforms Label Dictionary to Label object.
 
         Args:
             a_dict (dict): Label Dictionary.
+            connection (CruxClient): Connection Object. Defaults to None.
 
         Returns:
             crux.models.Label: Label Object.
         """
-        return cls(raw_model=a_dict)
+        return cls(raw_model=a_dict, connection=connection)

--- a/crux/models/permission.py
+++ b/crux/models/permission.py
@@ -2,19 +2,25 @@
 
 from typing import Dict  # noqa: F401
 
+from crux._client import CruxClient
+from crux._config import CruxConfig
 from crux.models.model import CruxModel
 
 
 class Permission(CruxModel):
     """Permission Model."""
 
-    def __init__(self, raw_model=None):
-        # type: (Dict) -> None
+    def __init__(self, raw_model=None, connection=None):
+        # type: (Dict, CruxClient) -> None
         """
         Attributes:
             raw_model (dict): Identity raw dictionary. Defaults to None.
+            connection (CruxClient): Connection Object. Defaults to None.
         """
         self.raw_model = raw_model if raw_model is not None else {}
+        self.connection = (
+            connection if connection is not None else CruxClient(CruxConfig(api_key=""))
+        )
 
     @property
     def target_id(self):
@@ -41,14 +47,14 @@ class Permission(CruxModel):
         return self.raw_model
 
     @classmethod
-    def from_dict(cls, a_dict):
-        # type: (Dict[str, str]) -> Permission
+    def from_dict(cls, a_dict, connection=None):
+        # type: (Dict[str, str], CruxClient) -> Permission
         """Transforms Dataset Dictionary to Dataset object.
 
         Args:
             a_dict (dict): Dataset Dictionary.
-
+            connection (CruxClient): Connection Object. Defaults to None.
         Returns:
             crux.models.Permission: Permission Object.
         """
-        return cls(raw_model=a_dict)
+        return cls(raw_model=a_dict, connection=connection)

--- a/crux/models/resource.py
+++ b/crux/models/resource.py
@@ -32,7 +32,7 @@ class Resource(CruxModel):
         self._folder = None
         self.raw_model = raw_model if raw_model is not None else {}
         self.connection = (
-            connection if connection is not None else CruxClient(CruxConfig())
+            connection if connection is not None else CruxClient(CruxConfig(api_key=""))
         )
 
     @property
@@ -166,18 +166,18 @@ class Resource(CruxModel):
         return self.raw_model
 
     @classmethod
-    def from_dict(cls, a_dict):
-        # type: (Dict[str, Any]) -> Any
+    def from_dict(cls, a_dict, connection=None):
+        # type: (Dict[str, Any], CruxClient) -> Any
         """Transforms Resource Dictionary to Resource object.
 
         Args:
             a_dict (dict): Resource Dictionary.
-
+            connection (CruxClient): Connection Object. Defaults to None.
         Returns:
             crux.models.Resource: Resource Object.
         """
 
-        return cls(raw_model=a_dict)
+        return cls(raw_model=a_dict, connection=connection)
 
     def delete(self):
         # type: () -> bool

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,3 +1,4 @@
+import os
 import random
 import string
 
@@ -16,6 +17,11 @@ class Helpers:
 @pytest.fixture
 def helpers():
     return Helpers
+
+
+@pytest.fixture(scope="module")
+def inline_connection():
+    return Crux(api_host=os.getenv("CRUX_API_HOST"), api_key=os.getenv("CRUX_API_KEY"))
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/test_dataset.py
+++ b/tests/integration/test_dataset.py
@@ -35,6 +35,12 @@ def test_whoami(connection):
     assert identity.type == "user"
 
 
+@pytest.mark.usefixtures("inline_connection")
+def test_whoami_inline(inline_connection):
+    identity = inline_connection.whoami()
+    assert identity.type == "user"
+
+
 @pytest.mark.skip(reason="Test is flaky")
 @pytest.mark.usefixtures("connection", "dataset")
 def test_set_datasets_provenance(connection, dataset):

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -24,43 +24,30 @@ from crux.models.model import CruxModel
 
 
 class SampleModel(CruxModel):
-    def __init__(self, attr_1=None, attr_2=None):
-        self._attr_1 = None
-        self._attr_2 = None
+    def __init__(self, raw_model=None, connection=None):
 
-        self.attr_1 = attr_1
-        self.attr_2 = attr_2
+        self.raw_model = raw_model
+        self.connection = connection
 
     @property
     def attr_1(self):
-        return self._attr_1
+        return self.raw_model["attr1"]
 
     @attr_1.setter
     def attr_1(self, attr_1):
-        self._attr_1 = attr_1
+        self.raw_model["attr1"] = attr_1
 
     @property
     def attr_2(self):
-        return self._attr_2
+        return self.raw_model["attr2"]
 
     @attr_2.setter
     def attr_2(self, attr_2):
-        self._attr_2 = attr_2
+        self.raw_model["attr1"] = attr_2
 
     @classmethod
-    def from_dict(cls, a_dict):
-        """Method which transforms SampleModel Dictionary to SampleModel object
-
-            Args:
-                cls(SampleModel): SampleModel Class
-                a_dict(dict): SampleModel Dictionary
-            Returns:
-                SampleModel(SampleModel): SampleModel Object
-        """
-        attr_1 = a_dict["attr1"]
-        attr_2 = a_dict["attr2"]
-
-        return cls(attr_1=attr_1, attr_2=attr_2)
+    def from_dict(cls, a_dict, connection=None):
+        return cls(raw_model=a_dict, connection=connection)
 
     def to_dict(self):
         """ Method which transforms SampleModel object to SampleModel Dictionary
@@ -70,7 +57,7 @@ class SampleModel(CruxModel):
         Returns:
             Resource(dict): SampleModel Dictionary
         """
-        return {"attr_1": self.attr_1, "attr_2": self.attr_2}
+        return self.raw_model
 
 
 @pytest.fixture
@@ -179,7 +166,7 @@ def monkeypatch_post_call(
 
 def test_client_post(client, monkeypatch):
     monkeypatch.setattr(requests.sessions.Session, "request", monkeypatch_post_call)
-    sample_obj = SampleModel(attr_1="attr1", attr_2="attr2")
+    sample_obj = SampleModel(raw_model={"attr1": "dummy1", "attr2": "dummy2"})
     resp = client.api_call(
         method="POST", path=["test-path"], model=SampleModel, json=sample_obj.to_dict()
     )
@@ -208,7 +195,7 @@ def monkeypatch_put_call(
 
 def test_client_put(client, monkeypatch):
     monkeypatch.setattr(requests.sessions.Session, "request", monkeypatch_put_call)
-    sample_obj = SampleModel(attr_1="attr1", attr_2="attr2")
+    sample_obj = SampleModel(raw_model={"attr1": "dummy1", "attr2": "dummy2"})
     resp = client.api_call(
         method="PUT", path=["test-path"], model=SampleModel, json=sample_obj.to_dict()
     )

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -16,8 +16,7 @@ def dataset():
         "description": "test_dataset_description",
         "tags": ["tags1"],
     }
-    dataset = Dataset(raw_model=raw_model)
-    dataset.connection = conn
+    dataset = Dataset(raw_model=raw_model, connection=conn)
     return dataset
 
 

--- a/tests/unit/test_resource.py
+++ b/tests/unit/test_resource.py
@@ -17,9 +17,9 @@ def resource():
             "type": "file",
             "tags": ["tags"],
             "description": "test_description",
-        }
+        },
+        connection=conn,
     )
-    resource.connection = conn
     return resource
 
 


### PR DESCRIPTION
- Connection object should be now passes to from_dict().
- Added connection object support for all models and their corresponding
methods.
- Updated factory method to support connection object.
- Added a integration test which passes configuration information
inline.
- Updated corresponding unit test cases.

## Verification

- make `format`, `lint`, `unit` & `integration` passes.