### PR TITLE
Fix models to allow connection to be set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ __pycache__/
 .pytest_cache/
 .mypy_cache/
 /pip-wheel-metadata/
+/.env

--- a/crux/_client.py
+++ b/crux/_client.py
@@ -154,15 +154,13 @@ class CruxClient(object):
                     log.debug("Response is list of type %s", model)
                     serial_list = []
                     for item in response.json():
-                        obj = model.from_dict(item)
-                        obj.connection = self
+                        obj = model.from_dict(item, connection=self)
                         serial_list.append(obj)
                     return serial_list
 
                 else:
                     log.debug("Response is of type %s", model)
-                    obj = model.from_dict(response.json())
-                    obj.connection = self
+                    obj = model.from_dict(response.json(), connection=self)
                     return obj
         elif response.status_code == 204:
             log.debug("Response code is 204, returning True boolean value")

--- a/crux/apis.py
+++ b/crux/apis.py
@@ -109,9 +109,10 @@ class Crux(object):
         raw_resource = response.json()
 
         resource = get_resource_object(
-            resource_type=raw_resource.get("type"), data=raw_resource
+            resource_type=raw_resource.get("type"),
+            data=raw_resource,
+            connection=self.api_client,
         )
-        resource.connection = self.api_client
         return resource
 
     def _call_drives_my(self):
@@ -141,12 +142,12 @@ class Crux(object):
 
         if owned:
             for dataset in datasets["owned"]:
-                obj = Dataset.from_dict(dataset)
+                obj = Dataset.from_dict(dataset, connection=self.api_client)
                 dataset_list.append(obj)
 
         if subscribed:
             for dataset in datasets["subscriptions"]:
-                obj = Dataset.from_dict(dataset)
+                obj = Dataset.from_dict(dataset, connection=self.api_client)
                 dataset_list.append(obj)
 
         return dataset_list

--- a/crux/models/_factory.py
+++ b/crux/models/_factory.py
@@ -2,17 +2,19 @@
 
 from typing import Any, Dict, Union  # noqa: F401
 
+from crux._client import CruxClient
 from crux.models.file import File
 from crux.models.folder import Folder
 
 
-def get_resource_object(resource_type, data):
-    # type: (str, Dict[str, Any]) -> Union[File, Folder]
+def get_resource_object(resource_type, data, connection=None):
+    # type: (str, Dict[str, Any], CruxClient) -> Union[File, Folder]
     """Creates resource object based on its type.
 
     Args:
         resource_type (str): Type of resource which needs to be created.
         data (dict): Dictionary which contains serialized resource data.
+        connection (CruxClient): Connection Object. Defaults to None.
 
     Returns:
         crux.models.Resource: Resource or its Child Object.
@@ -21,8 +23,8 @@ def get_resource_object(resource_type, data):
         TypeError: If it is unable to detect resource type.
     """
     if resource_type == "file":
-        return File.from_dict(data)
+        return File.from_dict(data, connection=connection)
     elif resource_type == "folder":
-        return Folder.from_dict(data)
+        return Folder.from_dict(data, connection=connection)
     else:
         raise TypeError("Invalid Resource Type")

--- a/crux/models/dataset.py
+++ b/crux/models/dataset.py
@@ -3,7 +3,6 @@
 import os
 import posixpath
 from typing import (
-    Any,
     Dict,
     IO,
     Iterator,
@@ -14,8 +13,6 @@ from typing import (
     Union,
 )  # noqa: F401
 
-from crux._client import CruxClient
-from crux._client import CruxConfig
 from crux._compat import unicode
 from crux._utils import create_logger, Headers, split_posixpath_filename_dirpath
 from crux.exceptions import CruxAPIError, CruxClientError, CruxResourceNotFoundError
@@ -34,18 +31,6 @@ log = create_logger(__name__)
 
 class Dataset(CruxModel):
     """Dataset Model."""
-
-    def __init__(self, raw_model=None, connection=None):
-        # type: (Dict, CruxClient) -> None
-        """
-        Attributes:
-            raw_model (dict): Dataset raw dictionary. Defaults to None.
-            connection (CruxClient): Connection Object. Defaults to None.
-        """
-        self.raw_model = raw_model if raw_model is not None else {}
-        self.connection = (
-            connection if connection is not None else CruxClient(CruxConfig(api_key=""))
-        )
 
     @property
     def id(self):
@@ -119,29 +104,6 @@ class Dataset(CruxModel):
         """str: Compute or Get the provenance."""
         return self.raw_model["provenance"]
 
-    def to_dict(self):
-        # type: () -> Dict[str, Any]
-        """Transforms Dataset object to Dataset Dictionary.
-
-        Returns:
-            dict: Dataset Dictionary.
-        """
-        return self.raw_model
-
-    @classmethod
-    def from_dict(cls, a_dict, connection=None):
-        # type: (Dict[str, Any], CruxClient) -> Dataset
-        """Transforms Dataset Dictionary to Dataset object.
-
-        Args:
-            a_dict (dict): Dataset Dictionary.
-            connection (CruxClient): Connection Object. Defaults to None.
-        Returns:
-            crux.models.Dataset: Dataset Object.
-        """
-
-        return cls(raw_model=a_dict, connection=connection)
-
     def create(self):
         # type: () -> bool
         """Creates the Dataset.
@@ -153,7 +115,7 @@ class Dataset(CruxModel):
             {"content-type": "application/json", "accept": "application/json"}
         )
         dataset_object = self.connection.api_call(
-            "POST", ["datasets"], json=self.to_dict(), model=Dataset, headers=headers
+            "POST", ["datasets"], json=self.raw_model, model=Dataset, headers=headers
         )
 
         self.raw_model = dataset_object.raw_model
@@ -197,7 +159,7 @@ class Dataset(CruxModel):
         if tags is not None:
             self.raw_model["tags"] = tags
 
-        body = self.to_dict()
+        body = self.raw_model
 
         dataset_object = self.connection.api_call(
             "PUT", ["datasets", self.id], headers=headers, json=body, model=Dataset
@@ -265,7 +227,7 @@ class Dataset(CruxModel):
         return self.connection.api_call(
             "POST",
             ["datasets", self.id, "resources"],
-            json=file_resource.to_dict(),
+            json=file_resource.raw_model,
             model=File,
             headers=headers,
         )
@@ -308,7 +270,7 @@ class Dataset(CruxModel):
         return self.connection.api_call(
             "POST",
             ["datasets", self.id, "resources"],
-            json=folder_resource.to_dict(),
+            json=folder_resource.raw_model,
             model=Folder,
             headers=headers,
         )

--- a/crux/models/identity.py
+++ b/crux/models/identity.py
@@ -1,28 +1,10 @@
 """Module contains Identity model."""
 
-from typing import Any, Dict  # noqa: F401
-
-from crux._client import CruxClient
-from crux._config import CruxConfig
 from crux.models.model import CruxModel
 
 
 class Identity(CruxModel):
     """Identity Model."""
-
-    def __init__(self, raw_model=None, connection=None):
-        # type: (Dict, CruxClient) -> None
-        """
-        Attributes:
-            raw_model (dict): Identity raw dictionary. Defaults to None.
-            connection (CruxClient): Connection Object. Defaults to None.
-        Raises:
-            ValueError: If name or tags are set to None.
-        """
-        self.raw_model = raw_model if raw_model is not None else {}
-        self.connection = (
-            connection if connection is not None else CruxClient(CruxConfig(api_key=""))
-        )
 
     @property
     def identity_id(self):
@@ -119,25 +101,3 @@ class Identity(CruxModel):
     @phone.setter
     def phone(self, phone):
         self.raw_model["phone"] = phone
-
-    def to_dict(self):
-        # type: () -> Dict[str, Any]
-        """Transforms Identity object to Identity Dictionary.
-
-        Returns:
-            dict: Identity Dictionary.
-        """
-        return self.raw_model
-
-    @classmethod
-    def from_dict(cls, a_dict, connection=None):
-        # type: (Dict[str, str], CruxClient) -> Identity
-        """Transforms Identity Dictionary to Identity object.
-
-        Args:
-            a_dict (dict): Identity Dictionary.
-            connection (CruxClient): Connection Object. Defaults to None.
-        Returns:
-            crux.models.Identity: Identity Object.
-        """
-        return cls(raw_model=a_dict, connection=connection)

--- a/crux/models/identity.py
+++ b/crux/models/identity.py
@@ -21,7 +21,7 @@ class Identity(CruxModel):
         """
         self.raw_model = raw_model if raw_model is not None else {}
         self.connection = (
-            connection if connection is not None else CruxClient(CruxConfig())
+            connection if connection is not None else CruxClient(CruxConfig(api_key=""))
         )
 
     @property
@@ -130,14 +130,14 @@ class Identity(CruxModel):
         return self.raw_model
 
     @classmethod
-    def from_dict(cls, a_dict):
-        # type: (Dict[str, str]) -> Identity
+    def from_dict(cls, a_dict, connection=None):
+        # type: (Dict[str, str], CruxClient) -> Identity
         """Transforms Identity Dictionary to Identity object.
 
         Args:
             a_dict (dict): Identity Dictionary.
-
+            connection (CruxClient): Connection Object. Defaults to None.
         Returns:
             crux.models.Identity: Identity Object.
         """
-        return cls(raw_model=a_dict)
+        return cls(raw_model=a_dict, connection=connection)

--- a/crux/models/job.py
+++ b/crux/models/job.py
@@ -2,6 +2,8 @@
 
 from typing import Dict  # noqa: F401
 
+from crux._client import CruxClient
+from crux._config import CruxConfig
 from crux.models.model import CruxModel
 
 
@@ -12,13 +14,17 @@ class AbstractJob(CruxModel):
 class Job(AbstractJob):
     """Job Model."""
 
-    def __init__(self, raw_model=None):
-        # type: (Dict) -> None
+    def __init__(self, raw_model=None, connection=None):
+        # type: (Dict, CruxClient) -> None
         """
         Attributes:
             raw_model (dict): Identity raw dictionary. Defaults to None.
+            connection (CruxClient): Connection Object. Defaults to None.
         """
         self.raw_model = raw_model if raw_model is not None else {}
+        self.connection = (
+            connection if connection is not None else CruxClient(CruxConfig(api_key=""))
+        )
 
     @property
     def job_id(self):
@@ -36,29 +42,34 @@ class Job(AbstractJob):
         return self.raw_model["statistics"]
 
     @classmethod
-    def from_dict(cls, a_dict):
-        # type: (Dict[str, str]) -> Job
+    def from_dict(cls, a_dict, connection=None):
+        # type: (Dict[str, str], CruxClient) -> Job
         """Transforms Job Dictionary to Job object.
 
         Args:
             a_dict (dict): Job Dictionary.
+            connection (CruxClient): Connection Object. Defaults to None.
 
         Returns:
             crux.models.Job: Job Object.
         """
-        return cls(raw_model=a_dict)
+        return cls(raw_model=a_dict, connection=connection)
 
 
 class StitchJob(AbstractJob):
     """Stitch Job Model."""
 
-    def __init__(self, raw_model=None):
-        # type: (Dict) -> None
+    def __init__(self, raw_model=None, connection=None):
+        # type: (Dict, CruxClient) -> None
         """
         Attributes:
             raw_model (dict): Identity raw dictionary. Defaults to None.
+            connection (CruxClient): Connection Object. Defaults to None.
         """
         self.raw_model = raw_model if raw_model is not None else {}
+        self.connection = (
+            connection if connection is not None else CruxClient(CruxConfig(api_key=""))
+        )
 
     @property
     def job_id(self):
@@ -71,14 +82,15 @@ class StitchJob(AbstractJob):
         return self.raw_model["status"]
 
     @classmethod
-    def from_dict(cls, a_dict):
-        # type: (Dict[str, str]) -> StitchJob
+    def from_dict(cls, a_dict, connection=None):
+        # type: (Dict[str, str], CruxClient) -> StitchJob
         """Transforms Stitch Job Dictionary to Stitch Job object.
 
         Args:
             a_dict (dict): Stitch Job Dictionary.
+            connection (CruxClient): Connection Object. Defaults to None.
 
         Returns:
             crux.models.job.StitchJob: Stitch Job Object.
         """
-        return cls(raw_model=a_dict)
+        return cls(raw_model=a_dict, connection=connection)

--- a/crux/models/job.py
+++ b/crux/models/job.py
@@ -1,9 +1,5 @@
 """Module contains AbstractJob, Job, LoadJob Model."""
 
-from typing import Dict  # noqa: F401
-
-from crux._client import CruxClient
-from crux._config import CruxConfig
 from crux.models.model import CruxModel
 
 
@@ -13,18 +9,6 @@ class AbstractJob(CruxModel):
 
 class Job(AbstractJob):
     """Job Model."""
-
-    def __init__(self, raw_model=None, connection=None):
-        # type: (Dict, CruxClient) -> None
-        """
-        Attributes:
-            raw_model (dict): Identity raw dictionary. Defaults to None.
-            connection (CruxClient): Connection Object. Defaults to None.
-        """
-        self.raw_model = raw_model if raw_model is not None else {}
-        self.connection = (
-            connection if connection is not None else CruxClient(CruxConfig(api_key=""))
-        )
 
     @property
     def job_id(self):
@@ -41,35 +25,9 @@ class Job(AbstractJob):
         """str: Gets the Job Statistics."""
         return self.raw_model["statistics"]
 
-    @classmethod
-    def from_dict(cls, a_dict, connection=None):
-        # type: (Dict[str, str], CruxClient) -> Job
-        """Transforms Job Dictionary to Job object.
-
-        Args:
-            a_dict (dict): Job Dictionary.
-            connection (CruxClient): Connection Object. Defaults to None.
-
-        Returns:
-            crux.models.Job: Job Object.
-        """
-        return cls(raw_model=a_dict, connection=connection)
-
 
 class StitchJob(AbstractJob):
     """Stitch Job Model."""
-
-    def __init__(self, raw_model=None, connection=None):
-        # type: (Dict, CruxClient) -> None
-        """
-        Attributes:
-            raw_model (dict): Identity raw dictionary. Defaults to None.
-            connection (CruxClient): Connection Object. Defaults to None.
-        """
-        self.raw_model = raw_model if raw_model is not None else {}
-        self.connection = (
-            connection if connection is not None else CruxClient(CruxConfig(api_key=""))
-        )
 
     @property
     def job_id(self):
@@ -80,17 +38,3 @@ class StitchJob(AbstractJob):
     def status(self):
         """str: Gets the Job Status."""
         return self.raw_model["status"]
-
-    @classmethod
-    def from_dict(cls, a_dict, connection=None):
-        # type: (Dict[str, str], CruxClient) -> StitchJob
-        """Transforms Stitch Job Dictionary to Stitch Job object.
-
-        Args:
-            a_dict (dict): Stitch Job Dictionary.
-            connection (CruxClient): Connection Object. Defaults to None.
-
-        Returns:
-            crux.models.job.StitchJob: Stitch Job Object.
-        """
-        return cls(raw_model=a_dict, connection=connection)

--- a/crux/models/label.py
+++ b/crux/models/label.py
@@ -1,26 +1,10 @@
 """Module contains Label model."""
 
-from typing import Any, Dict
-
-from crux._client import CruxClient
-from crux._config import CruxConfig
 from crux.models.model import CruxModel
 
 
 class Label(CruxModel):
     """Label Model."""
-
-    def __init__(self, raw_model=None, connection=None):
-        # type: (Dict, CruxClient) -> None
-        """
-        Attributes:
-            raw_model (dict): Identity raw dictionary. Defaults to None.
-            connection (CruxClient): Connection Object. Defaults to None.
-        """
-        self.raw_model = raw_model if raw_model is not None else {}
-        self.connection = (
-            connection if connection is not None else CruxClient(CruxConfig(api_key=""))
-        )
 
     @property
     def label_key(self):
@@ -31,26 +15,3 @@ class Label(CruxModel):
     def label_value(self):
         """str: Gets the Label Value."""
         return self.raw_model["labelValue"]
-
-    def to_dict(self):
-        # type: () -> Dict[str, Any]
-        """Transforms Label object to Label Dictionary.
-
-        Returns:
-            dict: Label Dictionary.
-        """
-        return self.raw_model
-
-    @classmethod
-    def from_dict(cls, a_dict, connection=None):
-        # type: (Dict[str,str], CruxClient) -> Label
-        """Transforms Label Dictionary to Label object.
-
-        Args:
-            a_dict (dict): Label Dictionary.
-            connection (CruxClient): Connection Object. Defaults to None.
-
-        Returns:
-            crux.models.Label: Label Object.
-        """
-        return cls(raw_model=a_dict, connection=connection)

--- a/crux/models/label.py
+++ b/crux/models/label.py
@@ -2,19 +2,25 @@
 
 from typing import Any, Dict
 
+from crux._client import CruxClient
+from crux._config import CruxConfig
 from crux.models.model import CruxModel
 
 
 class Label(CruxModel):
     """Label Model."""
 
-    def __init__(self, raw_model=None):
-        # type: (Dict) -> None
+    def __init__(self, raw_model=None, connection=None):
+        # type: (Dict, CruxClient) -> None
         """
         Attributes:
             raw_model (dict): Identity raw dictionary. Defaults to None.
+            connection (CruxClient): Connection Object. Defaults to None.
         """
         self.raw_model = raw_model if raw_model is not None else {}
+        self.connection = (
+            connection if connection is not None else CruxClient(CruxConfig(api_key=""))
+        )
 
     @property
     def label_key(self):
@@ -36,14 +42,15 @@ class Label(CruxModel):
         return self.raw_model
 
     @classmethod
-    def from_dict(cls, a_dict):
-        # type: (Dict[str,str]) -> Label
+    def from_dict(cls, a_dict, connection=None):
+        # type: (Dict[str,str], CruxClient) -> Label
         """Transforms Label Dictionary to Label object.
 
         Args:
             a_dict (dict): Label Dictionary.
+            connection (CruxClient): Connection Object. Defaults to None.
 
         Returns:
             crux.models.Label: Label Object.
         """
-        return cls(raw_model=a_dict)
+        return cls(raw_model=a_dict, connection=connection)

--- a/crux/models/model.py
+++ b/crux/models/model.py
@@ -1,18 +1,69 @@
 """Module defines abstract CruxModel."""
 
+import copy
 import pprint
+from typing import Any, Dict  # noqa: F401
+
+from crux._client import CruxClient
+from crux._client import CruxConfig
 
 
 class CruxModel(object):
-    """Absract Crux Model."""
+    """Base Crux model."""
+
+    def __init__(self, raw_model=None, connection=None):
+        # type: (Dict, CruxClient) -> None
+        """
+        Attributes:
+            raw_model (dict): Resource raw dictionary. Defaults to None.
+            connection (CruxClient): Connection object. Defaults to None.
+        """
+        self.raw_model = raw_model if raw_model is not None else {}
+        self._connection = connection
+
+    @property
+    def connection(self):
+        """CruxClient: API connection client."""
+        if self._connection is None:
+            self._connection = CruxClient(CruxConfig())
+
+        return self._connection
+
+    @connection.setter
+    def connection(self, connection):
+        self._connection = connection
 
     def to_dict(self):
-        """Absract to_dict method."""
+        # type: () -> Dict[str, Any]
+        """Returns dict copy of raw model.
+
+        Returns:
+            dict: Raw model dict.
+        """
+
+        # Deep copy raw_model, otherwise if a user modifies the returned dict,
+        # they will be mutating this instances raw_model.
+        return copy.deepcopy(self.raw_model)
+
+    @classmethod
+    def from_dict(cls, a_dict, connection=None):
+        # type: (Dict[str, Any], CruxClient) -> Any
+        """Returns model instance created from raw model dict.
+
+        Args:
+            a_dict (dict): Model dict.
+            connection (CruxClient): Connection bbject. Defaults to None.
+
+        Returns:
+            crux.models.model.CruxModel: Model instance.
+        """
+
+        return cls(raw_model=a_dict, connection=connection)
 
     def to_str(self):
         # type: () -> str
         """Absract to_str method."""
-        return pprint.pformat(self.to_dict())
+        return pprint.pformat(self.raw_model)
 
     def __repr__(self):
         # type: () -> str

--- a/crux/models/permission.py
+++ b/crux/models/permission.py
@@ -2,19 +2,25 @@
 
 from typing import Dict  # noqa: F401
 
+from crux._client import CruxClient
+from crux._config import CruxConfig
 from crux.models.model import CruxModel
 
 
 class Permission(CruxModel):
     """Permission Model."""
 
-    def __init__(self, raw_model=None):
-        # type: (Dict) -> None
+    def __init__(self, raw_model=None, connection=None):
+        # type: (Dict, CruxClient) -> None
         """
         Attributes:
             raw_model (dict): Identity raw dictionary. Defaults to None.
+            connection (CruxClient): Connection Object. Defaults to None.
         """
         self.raw_model = raw_model if raw_model is not None else {}
+        self.connection = (
+            connection if connection is not None else CruxClient(CruxConfig(api_key=""))
+        )
 
     @property
     def target_id(self):
@@ -41,14 +47,14 @@ class Permission(CruxModel):
         return self.raw_model
 
     @classmethod
-    def from_dict(cls, a_dict):
-        # type: (Dict[str, str]) -> Permission
+    def from_dict(cls, a_dict, connection=None):
+        # type: (Dict[str, str], CruxClient) -> Permission
         """Transforms Dataset Dictionary to Dataset object.
 
         Args:
             a_dict (dict): Dataset Dictionary.
-
+            connection (CruxClient): Connection Object. Defaults to None.
         Returns:
             crux.models.Permission: Permission Object.
         """
-        return cls(raw_model=a_dict)
+        return cls(raw_model=a_dict, connection=connection)

--- a/crux/models/permission.py
+++ b/crux/models/permission.py
@@ -1,26 +1,10 @@
 """Module contains Permission model."""
 
-from typing import Dict  # noqa: F401
-
-from crux._client import CruxClient
-from crux._config import CruxConfig
 from crux.models.model import CruxModel
 
 
 class Permission(CruxModel):
     """Permission Model."""
-
-    def __init__(self, raw_model=None, connection=None):
-        # type: (Dict, CruxClient) -> None
-        """
-        Attributes:
-            raw_model (dict): Identity raw dictionary. Defaults to None.
-            connection (CruxClient): Connection Object. Defaults to None.
-        """
-        self.raw_model = raw_model if raw_model is not None else {}
-        self.connection = (
-            connection if connection is not None else CruxClient(CruxConfig(api_key=""))
-        )
 
     @property
     def target_id(self):
@@ -36,25 +20,3 @@ class Permission(CruxModel):
     def permission_name(self):
         """str: Gets the Permission Name."""
         return self.raw_model["permissionName"]
-
-    def to_dict(self):
-        # type: () -> Dict[str, str]
-        """Transforms Dataset object to Dataset Dictionary.
-
-        Returns:
-            dict: Dataset Dictionary.
-        """
-        return self.raw_model
-
-    @classmethod
-    def from_dict(cls, a_dict, connection=None):
-        # type: (Dict[str, str], CruxClient) -> Permission
-        """Transforms Dataset Dictionary to Dataset object.
-
-        Args:
-            a_dict (dict): Dataset Dictionary.
-            connection (CruxClient): Connection Object. Defaults to None.
-        Returns:
-            crux.models.Permission: Permission Object.
-        """
-        return cls(raw_model=a_dict, connection=connection)

--- a/crux/models/resource.py
+++ b/crux/models/resource.py
@@ -3,12 +3,11 @@
 from enum import Enum
 import os
 import posixpath
-from typing import Any, Dict, List, Union  # noqa: F401
+from typing import Dict, List, Union  # noqa: F401
 
 from requests.models import Response  # noqa: F401 pylint: disable=unused-import
 
 from crux._client import CruxClient
-from crux._config import CruxConfig
 from crux._utils import create_logger, DEFAULT_CHUNK_SIZE, Headers
 from crux.models.model import CruxModel
 from crux.models.permission import Permission
@@ -26,14 +25,9 @@ class Resource(CruxModel):
         Attributes:
             raw_model (dict): Resource raw dictionary. Defaults to None.
             connection (CruxClient): Connection Object. Defaults to None.
-        Raises:
-            ValueError: If name or tags are set to None.
         """
         self._folder = None
-        self.raw_model = raw_model if raw_model is not None else {}
-        self.connection = (
-            connection if connection is not None else CruxClient(CruxConfig(api_key=""))
-        )
+        super(Resource, self).__init__(raw_model, connection)
 
     @property
     def id(self):
@@ -156,29 +150,6 @@ class Resource(CruxModel):
         self._folder = self._get_folder()
         return self._folder
 
-    def to_dict(self):
-        # type: () -> Dict[str, Any]
-        """Transforms Resource object to Resource Dictionary.
-
-        Returns:
-            dict: Resource Dictionary.
-        """
-        return self.raw_model
-
-    @classmethod
-    def from_dict(cls, a_dict, connection=None):
-        # type: (Dict[str, Any], CruxClient) -> Any
-        """Transforms Resource Dictionary to Resource object.
-
-        Args:
-            a_dict (dict): Resource Dictionary.
-            connection (CruxClient): Connection Object. Defaults to None.
-        Returns:
-            crux.models.Resource: Resource Object.
-        """
-
-        return cls(raw_model=a_dict, connection=connection)
-
     def delete(self):
         # type: () -> bool
         """Deletes Resource from Dataset.
@@ -224,7 +195,7 @@ class Resource(CruxModel):
         if provenance is not None:
             self.raw_model["provenance"] = provenance
 
-        body = self.to_dict()
+        body = self.raw_model
 
         log.debug("Body %s", body)
 

--- a/crux/models/resource.py
+++ b/crux/models/resource.py
@@ -32,7 +32,7 @@ class Resource(CruxModel):
         self._folder = None
         self.raw_model = raw_model if raw_model is not None else {}
         self.connection = (
-            connection if connection is not None else CruxClient(CruxConfig())
+            connection if connection is not None else CruxClient(CruxConfig(api_key=""))
         )
 
     @property
@@ -166,18 +166,18 @@ class Resource(CruxModel):
         return self.raw_model
 
     @classmethod
-    def from_dict(cls, a_dict):
-        # type: (Dict[str, Any]) -> Any
+    def from_dict(cls, a_dict, connection=None):
+        # type: (Dict[str, Any], CruxClient) -> Any
         """Transforms Resource Dictionary to Resource object.
 
         Args:
             a_dict (dict): Resource Dictionary.
-
+            connection (CruxClient): Connection Object. Defaults to None.
         Returns:
             crux.models.Resource: Resource Object.
         """
 
-        return cls(raw_model=a_dict)
+        return cls(raw_model=a_dict, connection=connection)
 
     def delete(self):
         # type: () -> bool

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,4 +1,3 @@
-import os
 import random
 import string
 
@@ -17,11 +16,6 @@ class Helpers:
 @pytest.fixture
 def helpers():
     return Helpers
-
-
-@pytest.fixture(scope="module")
-def inline_connection():
-    return Crux(api_host=os.getenv("CRUX_API_HOST"), api_key=os.getenv("CRUX_API_KEY"))
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,3 +1,4 @@
+import os
 import random
 import string
 
@@ -16,6 +17,11 @@ class Helpers:
 @pytest.fixture
 def helpers():
     return Helpers
+
+
+@pytest.fixture(scope="module")
+def inline_connection():
+    return Crux(api_host=os.getenv("CRUX_API_HOST"), api_key=os.getenv("CRUX_API_KEY"))
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -1,0 +1,28 @@
+import os
+
+import pytest
+
+from crux import Crux
+
+
+@pytest.mark.usefixtures("connection")
+def test_whoami(connection):
+    identity = connection.whoami()
+    assert identity.type == "user"
+
+
+def test_whoami_inline(monkeypatch):
+    api_host = os.getenv("CRUX_API_HOST")
+    api_key = os.getenv("CRUX_API_KEY")
+    monkeypatch.delenv("CRUX_API_HOST", raising=False)
+    monkeypatch.delenv("CRUX_API_KEY", raising=False)
+    connection = Crux(api_host=api_host, api_key=api_key)
+    identity = connection.whoami()
+    assert identity.type == "user"
+
+
+def test_api_key_required(monkeypatch):
+    monkeypatch.delenv("CRUX_API_HOST", raising=False)
+    monkeypatch.delenv("CRUX_API_KEY", raising=False)
+    with pytest.raises(ValueError):
+        Crux()

--- a/tests/integration/test_dataset.py
+++ b/tests/integration/test_dataset.py
@@ -29,18 +29,6 @@ def test_create_get_delete_dataset(connection, helpers):
         dataset.delete()
 
 
-@pytest.mark.usefixtures("connection")
-def test_whoami(connection):
-    identity = connection.whoami()
-    assert identity.type == "user"
-
-
-@pytest.mark.usefixtures("inline_connection")
-def test_whoami_inline(inline_connection):
-    identity = inline_connection.whoami()
-    assert identity.type == "user"
-
-
 @pytest.mark.skip(reason="Test is flaky")
 @pytest.mark.usefixtures("connection", "dataset")
 def test_set_datasets_provenance(connection, dataset):

--- a/tests/integration/test_dataset.py
+++ b/tests/integration/test_dataset.py
@@ -35,6 +35,12 @@ def test_whoami(connection):
     assert identity.type == "user"
 
 
+@pytest.mark.usefixtures("inline_connection")
+def test_whoami_inline(inline_connection):
+    identity = inline_connection.whoami()
+    assert identity.type == "user"
+
+
 @pytest.mark.skip(reason="Test is flaky")
 @pytest.mark.usefixtures("connection", "dataset")
 def test_set_datasets_provenance(connection, dataset):

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -24,11 +24,6 @@ from crux.models.model import CruxModel
 
 
 class SampleModel(CruxModel):
-    def __init__(self, raw_model=None, connection=None):
-
-        self.raw_model = raw_model
-        self.connection = connection
-
     @property
     def attr_1(self):
         return self.raw_model["attr1"]
@@ -44,20 +39,6 @@ class SampleModel(CruxModel):
     @attr_2.setter
     def attr_2(self, attr_2):
         self.raw_model["attr1"] = attr_2
-
-    @classmethod
-    def from_dict(cls, a_dict, connection=None):
-        return cls(raw_model=a_dict, connection=connection)
-
-    def to_dict(self):
-        """ Method which transforms SampleModel object to SampleModel Dictionary
-
-        Args:
-            self: SampleModel instance Object
-        Returns:
-            Resource(dict): SampleModel Dictionary
-        """
-        return self.raw_model
 
 
 @pytest.fixture
@@ -168,7 +149,7 @@ def test_client_post(client, monkeypatch):
     monkeypatch.setattr(requests.sessions.Session, "request", monkeypatch_post_call)
     sample_obj = SampleModel(raw_model={"attr1": "dummy1", "attr2": "dummy2"})
     resp = client.api_call(
-        method="POST", path=["test-path"], model=SampleModel, json=sample_obj.to_dict()
+        method="POST", path=["test-path"], model=SampleModel, json=sample_obj.raw_model
     )
 
     assert resp.attr_1 == "dummy1"
@@ -197,7 +178,7 @@ def test_client_put(client, monkeypatch):
     monkeypatch.setattr(requests.sessions.Session, "request", monkeypatch_put_call)
     sample_obj = SampleModel(raw_model={"attr1": "dummy1", "attr2": "dummy2"})
     resp = client.api_call(
-        method="PUT", path=["test-path"], model=SampleModel, json=sample_obj.to_dict()
+        method="PUT", path=["test-path"], model=SampleModel, json=sample_obj.raw_model
     )
 
     assert resp.attr_1 == "dummy1"

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -24,43 +24,30 @@ from crux.models.model import CruxModel
 
 
 class SampleModel(CruxModel):
-    def __init__(self, attr_1=None, attr_2=None):
-        self._attr_1 = None
-        self._attr_2 = None
+    def __init__(self, raw_model=None, connection=None):
 
-        self.attr_1 = attr_1
-        self.attr_2 = attr_2
+        self.raw_model = raw_model
+        self.connection = connection
 
     @property
     def attr_1(self):
-        return self._attr_1
+        return self.raw_model["attr1"]
 
     @attr_1.setter
     def attr_1(self, attr_1):
-        self._attr_1 = attr_1
+        self.raw_model["attr1"] = attr_1
 
     @property
     def attr_2(self):
-        return self._attr_2
+        return self.raw_model["attr2"]
 
     @attr_2.setter
     def attr_2(self, attr_2):
-        self._attr_2 = attr_2
+        self.raw_model["attr1"] = attr_2
 
     @classmethod
-    def from_dict(cls, a_dict):
-        """Method which transforms SampleModel Dictionary to SampleModel object
-
-            Args:
-                cls(SampleModel): SampleModel Class
-                a_dict(dict): SampleModel Dictionary
-            Returns:
-                SampleModel(SampleModel): SampleModel Object
-        """
-        attr_1 = a_dict["attr1"]
-        attr_2 = a_dict["attr2"]
-
-        return cls(attr_1=attr_1, attr_2=attr_2)
+    def from_dict(cls, a_dict, connection=None):
+        return cls(raw_model=a_dict, connection=connection)
 
     def to_dict(self):
         """ Method which transforms SampleModel object to SampleModel Dictionary
@@ -70,7 +57,7 @@ class SampleModel(CruxModel):
         Returns:
             Resource(dict): SampleModel Dictionary
         """
-        return {"attr_1": self.attr_1, "attr_2": self.attr_2}
+        return self.raw_model
 
 
 @pytest.fixture
@@ -179,7 +166,7 @@ def monkeypatch_post_call(
 
 def test_client_post(client, monkeypatch):
     monkeypatch.setattr(requests.sessions.Session, "request", monkeypatch_post_call)
-    sample_obj = SampleModel(attr_1="attr1", attr_2="attr2")
+    sample_obj = SampleModel(raw_model={"attr1": "dummy1", "attr2": "dummy2"})
     resp = client.api_call(
         method="POST", path=["test-path"], model=SampleModel, json=sample_obj.to_dict()
     )
@@ -208,7 +195,7 @@ def monkeypatch_put_call(
 
 def test_client_put(client, monkeypatch):
     monkeypatch.setattr(requests.sessions.Session, "request", monkeypatch_put_call)
-    sample_obj = SampleModel(attr_1="attr1", attr_2="attr2")
+    sample_obj = SampleModel(raw_model={"attr1": "dummy1", "attr2": "dummy2"})
     resp = client.api_call(
         method="PUT", path=["test-path"], model=SampleModel, json=sample_obj.to_dict()
     )

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -16,8 +16,7 @@ def dataset():
         "description": "test_dataset_description",
         "tags": ["tags1"],
     }
-    dataset = Dataset(raw_model=raw_model)
-    dataset.connection = conn
+    dataset = Dataset(raw_model=raw_model, connection=conn)
     return dataset
 
 

--- a/tests/unit/test_resource.py
+++ b/tests/unit/test_resource.py
@@ -17,9 +17,9 @@ def resource():
             "type": "file",
             "tags": ["tags"],
             "description": "test_description",
-        }
+        },
+        connection=conn,
     )
-    resource.connection = conn
     return resource
 
 


### PR DESCRIPTION
Prior to 0.0.12 new model instances could be created without a client
connection, and the connection could be added later. 0.0.12 prevented
that from happening, the previous behavior is required for backwards
compatibility.

- Add `connection` arg to model `__init__()`.
- Add `connection` arg to model `from_dict()`.
- Change `CruxModel.connection` to a property that will lazily create a
  connection the first time it is used, allowing the connection to be
  set after the instance is created.
- Move `__init__()` to `CruxModel` base class instead of subclasses,
  because it is nearly the same for all subclasses.
- Move `to_dict()` and `from_dict()` to `CruxModel` base class instead
  of subclasses, because they are the same for all subclasses.
- Change `to_dict()` to `copy.deepcopy(self.raw_model)`, otherwise if
  the returned `dict` is modified it will mutate the `raw_model` of the
  other model instance. Change all `to_dict()` calls to `raw_model` to
  avoid deep copy, unless they need a deep copy.
- Add test for passing `api_host` and `api_key` without environment
  variables being set.
- Add test for replacing the connection of a resource.

This PR includes the changes from PR #48.

**Test Plan:**

- Tested `monkeypatch.delenv()` by removing `api_host` and `api_key`
  from the fixture, to ensure the test would have failed if those args
  were not working.
- Checked uses of raw_model in the code to make sure it isn't being
  passed to something that will mutate it.
- All nox tests pass:

```
nox > * lint-3.7: success
nox > * unit-2.7: success
nox > * unit-3.5: success
nox > * unit-3.6: success
nox > * unit-3.7: success
nox > * integration-2.7: success
nox > * integration-3.5: success
nox > * integration-3.6: success
nox > * integration-3.7: success
nox > * format_check-3.7: success
nox > * type_check-3.7: success
```