### PR TITLE
Using Generator for list calls 

### DIFF
--- a/crux/_client.py
+++ b/crux/_client.py
@@ -59,7 +59,7 @@ class CruxClient(object):
         stream=False,  # type: bool
         connect_timeout=9.5,  # type: float
         read_timeout=60,  # type: float
-        paginate = {}
+        paginate=None
     ):
         # type:(...) -> Any
         """
@@ -79,6 +79,7 @@ class CruxClient(object):
                 Defaults to 60.5.
             read_timeout (float): Request read timeout configuration in seconds.
                 Defaults to 60.
+            paginate (dict): Dictionary to store pagination params
 
         Returns:
             crux.models.Model or bool: Serialized response from API backend.
@@ -106,6 +107,9 @@ class CruxClient(object):
 
         if params is None:
             params = {}
+
+        if paginate is None:
+            paginate = {}
 
         auth_scheme = "Bearer"  # type: str
         bearer_token = "{scheme} {key}".format(

--- a/crux/models/dataset.py
+++ b/crux/models/dataset.py
@@ -528,7 +528,7 @@ class Dataset(CruxModel):
         return uploaded_file_objects
 
     def list_files(self, sort=None, folder="/", cursor=None, limit=100):
-        # type: (str, str, int, int) -> List[File]
+        # type: (str, str, str, int) -> List[File]
         """Lists the files.
 
         Args:

--- a/tests/integration/test_upload_download.py
+++ b/tests/integration/test_upload_download.py
@@ -21,9 +21,11 @@ def test_upload_download_files(dataset, helpers):
     for file_object in file_objects:
         assert file_object.name in ["test_file.csv", "test_file_2.csv"]
     download_dir = mkdtemp()
-    downloaded_file_list = dataset.download_files(
+    downloaded_file_list_gen = dataset.download_files(
         local_path=download_dir, folder=folder_path
     )
+
+    downloaded_file_list = [downloaded_file for downloaded_file in downloaded_file_list_gen]
     assert len(downloaded_file_list) == 2
     download_path = os.path.join(download_dir, "test_file.csv")
     assert sorted(downloaded_file_list)[0] == download_path


### PR DESCRIPTION
Make fetch resource list calls flexible by using generators.

Retain py2.7 support:
* avoid using `yield from`