### PR TITLE
bump version to 0.0.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Install `crux` [from PyPI](https://pypi.org/project/crux/) in a virtual environm
 ```bash
 mkdir -p crux_example
 cd crux_example
-pipenv install "crux==0.0.16"
+pipenv install "crux==0.0.17"
 pipenv shell
 ```
 ## Getting Started

--- a/crux/__version__.py
+++ b/crux/__version__.py
@@ -1,3 +1,3 @@
 """Module contains version and other package information."""
 
-__version__ = "0.0.16"
+__version__ = "0.0.17"

--- a/docs/_release_process.md
+++ b/docs/_release_process.md
@@ -21,20 +21,20 @@ There are various places in the source repository where we explicitly list the v
 Search the code to find all references to the current version, for example:
 
 ```
-$ rg -F '0.0.16'
+$ rg -F '0.0.17'
 README.md
-27:pipenv install "crux==0.0.16"
+27:pipenv install "crux==0.0.17"
 
 docs/index.md
-27:pipenv install "crux==0.0.16"
+27:pipenv install "crux==0.0.17"
 
 docs/installation.md
-20:pipenv install "crux==0.0.16"
-26:crux = "==0.0.16"
-36:python3 -m pip install "crux==0.0.16"
+20:pipenv install "crux==0.0.17"
+26:crux = "==0.0.17"
+36:python3 -m pip install "crux==0.0.17"
 
 crux/__version__.py
-3:__version__ = "0.0.16"
+3:__version__ = "0.0.17"
 ```
 
 Update all the versions. This could also be a good opportunity to double check that all tests pass.
@@ -71,8 +71,8 @@ Once the "bump" PR is merged, we create a GitHub release and tag the bump commit
 
 1. Go to [github.com/cruxinformatics/crux-python](https://github.com/cruxinformatics/crux-python) and click **releases**.
 2. Click **Draft new release**.
-3. In the **Tag version** field enter the version number prefixed with a *v*, e.g., `v0.0.16`. The **Target** will remain *master*, assuming the version bump commit is the latest commit on master, otherwise change the target to the bump commit.
-4. In **Release title** enter the tag version, e.g., `v0.0.16`.
+3. In the **Tag version** field enter the version number prefixed with a *v*, e.g., `v0.0.17`. The **Target** will remain *master*, assuming the version bump commit is the latest commit on master, otherwise change the target to the bump commit.
+4. In **Release title** enter the tag version, e.g., `v0.0.17`.
 5. In **Describe this release** use the same change lists as in the commit body, plus Markdown syntax to make the headings bold.
 6. Check the **This is a pre-release** box (until crux-python is no longer alpha or beta).
 7. Click **Publish release**.

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ Install `crux` [from PyPI](https://pypi.org/project/crux/) in a virtual environm
 ```bash
 mkdir -p crux_example
 cd crux_example
-pipenv install "crux==0.0.16"
+pipenv install "crux==0.0.17"
 pipenv shell
 ```
 ## Getting Started

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -17,13 +17,13 @@ See the [Pipenv installation instructions](https://pipenv.readthedocs.io/en/late
 Once Pipenv is installed, change into the root of your application directory and run:
 
 ```bash
-pipenv install "crux==0.0.16"
+pipenv install "crux==0.0.17"
 ```
 
 This will add a line to the `[packages]` section of your Pipfile, or create a new Pipfile if one doesn't exist.
 
 ```ini
-crux = "==0.0.16"
+crux = "==0.0.17"
 ```
 
 ## With venv and pip
@@ -33,6 +33,6 @@ Alternatively you can create a virtual environment with Python 3's [venv module]
 ```bash
 python3 -m venv .venv
 source .venv/bin/activate
-python3 -m pip install "crux==0.0.16"
+python3 -m pip install "crux==0.0.17"
 python3 -m pip freeze > requirements.txt
 ```


### PR DESCRIPTION
Bump version to 0.0.17

BREAKING CHANGES:

- None

Changes:

- Update sphinx documentation engine (internal)
- Update delivery endpoints to support caching
- Drive endpoint now relies on domain v2 as catalog data source