### PR TITLE
Bump version to 1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Install `crux` [from PyPI](https://pypi.org/project/crux/) in a virtual environm
 ```bash
 mkdir -p crux_example
 cd crux_example
-pipenv install "crux==1.2"
+pipenv install "crux==1.3"
 pipenv shell
 ```
 ## Getting Started

--- a/crux/__version__.py
+++ b/crux/__version__.py
@@ -1,3 +1,3 @@
 """Module contains version and other package information."""
 
-__version__ = "1.2"
+__version__ = "1.3"

--- a/docs/_release_process.md
+++ b/docs/_release_process.md
@@ -23,18 +23,18 @@ Search the code to find all references to the current version, for example:
 ```
 $ rg -F '1.1'
 README.md
-27:pipenv install "crux==1.2"
+27:pipenv install "crux==1.3"
 
 docs/index.md
-27:pipenv install "crux==1.2"
+27:pipenv install "crux==1.3"
 
 docs/installation.md
-20:pipenv install "crux==1.2"
-26:crux = "==1.1"
-36:python3 -m pip install "crux==1.2"
+20:pipenv install "crux==1.3"
+26:crux = "==1.3"
+36:python3 -m pip install "crux==1.3"
 
 crux/__version__.py
-3:__version__ = "1.1"
+3:__version__ = "1.3"
 ```
 
 Update all the versions. This could also be a good opportunity to double check that all tests pass.

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ Install `crux` [from PyPI](https://pypi.org/project/crux/) in a virtual environm
 ```bash
 mkdir -p crux_example
 cd crux_example
-pipenv install "crux==1.2"
+pipenv install "crux==1.3"
 pipenv shell
 ```
 ## Getting Started

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -17,13 +17,13 @@ See the [Pipenv installation instructions](https://pipenv.readthedocs.io/en/late
 Once Pipenv is installed, change into the root of your application directory and run:
 
 ```bash
-pipenv install "crux==1.2"
+pipenv install "crux==1.3"
 ```
 
 This will add a line to the `[packages]` section of your Pipfile, or create a new Pipfile if one doesn't exist.
 
 ```ini
-crux = "==1.1"
+crux = "==1.3"
 ```
 
 ## With venv and pip
@@ -33,6 +33,6 @@ Alternatively you can create a virtual environment with Python 3's [venv module]
 ```bash
 python3 -m venv .venv
 source .venv/bin/activate
-python3 -m pip install "crux==1.2"
+python3 -m pip install "crux==1.3"
 python3 -m pip freeze > requirements.txt
 ```


### PR DESCRIPTION
Bump version to 1.3

BREAKING CHANGES:

None
Changes:

Use v1/client  v2/client for all supported calls instead of plat-api
Remove API Reference
