### PR TITLE
Incorporating change for urllib3 moving from method_whitelist as a param to allowed_methods

### DIFF
--- a/crux/_config.py
+++ b/crux/_config.py
@@ -125,7 +125,7 @@ class CruxConfig(object):
                     527,
                     530,
                 ),
-                method_whitelist=("GET", "PUT", "DELETE", "POST"),
+                allowed_methods=("GET", "PUT", "DELETE", "POST"),
                 redirect=10,
                 connect=10,
                 read=10,


### PR DESCRIPTION
Fix for [Issue-93](https://github.com/cruxinformatics/crux-python/issues/93).